### PR TITLE
Add course-plan assignment publishing and Canvas sync improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+`lms_interface/` contains the library code. Key modules include `canvas_interface.py` (Canvas API integration), `backends.py`/`interfaces.py` (backend abstraction), `privacy.py` (FERPA-friendly redaction), and `helpers.py` (CLI helpers such as `cleanup-missing`).
+
+Tests live in `lms_interface/tests/` and mirror module behavior (`test_canvas_interface.py`, `test_helpers.py`, `test_privacy.py`). Keep new tests in this directory so vendoring stays clean.
+
+Repository utilities live in `scripts/`:
+- `install_git_hooks.sh` installs local hooks and `git bump`.
+- `git_bump.sh` bumps version, runs tests, updates `uv.lock`, and commits.
+- `vendor_into_project.py` vendors this package into downstream tools.
+
+## Build, Test, and Development Commands
+- `uv sync --dev`: install runtime and dev dependencies from `pyproject.toml`/`uv.lock`.
+- `uv run pytest -q`: run the full test suite (default `testpaths` is `lms_interface/tests`).
+- `uv run ruff check lms_interface lms_interface/tests`: run lint/import-order checks.
+- `uv run black lms_interface lms_interface/tests`: format code (88-char lines).
+- `bash scripts/install_git_hooks.sh`: enable repo hooks (`.githooks/pre-commit`).
+- `uv lock`: regenerate lockfile after dependency or version updates.
+
+## Coding Style & Naming Conventions
+Use Python 3.12 and 4-space indentation. Follow Black formatting (`line-length = 88`) and keep imports Ruff-clean (`I` rules enabled). Use `snake_case` for functions/variables, `PascalCase` for classes, and `test_*.py` for test modules.
+
+Prefer small, focused functions and explicit names around LMS concepts (`CanvasCourse`, `PrivacyBackend`, etc.).
+
+## Testing Guidelines
+Use `pytest` for all tests. Add regression tests for bug fixes and behavior changes, especially for Canvas request/response handling and privacy redaction paths.
+
+Name tests clearly by behavior (for example, `test_cleanup_missing_skips_future_due_assignments`). Run `uv run pytest -q` before opening a PR.
+
+## Commit & Pull Request Guidelines
+Commit messages in this repo are short, imperative, and task-focused (for example, `Add LMS backend abstractions`, `Bump to version 0.4.4`).
+
+PRs should follow `.github/pull_request_template.md`: include a clear description, change type, testing performed, and any relevant screenshots/notes. If `pyproject.toml` version changes, stage `uv.lock` in the same commit (enforced by pre-commit hook).
+
+## Security & Configuration Tips
+Store Canvas credentials in environment variables (`CANVAS_API_URL`, `CANVAS_API_KEY`, plus optional `_prod` variants). Never commit secrets or real student-identifying data.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,71 @@ Recommended rollout:
 3. Run course-wide with `--dry-run`.
 4. Run course-wide live.
 
+## Course Plan Helper
+
+Generate a student-facing calendar (HTML + JSON) from a course plan YAML and
+optionally publish it to Canvas as a page.
+
+Dry-run / local generation only:
+
+```bash
+lms-interface-helper plan-course --yaml-path course_plans/cst334_compact.yaml --output-dir build/cst334
+```
+
+Publish to Canvas:
+
+```bash
+lms-interface-helper plan-course --yaml-path course_plans/cst334_compact.yaml --course-id <COURSE_ID> --publish
+```
+
+Useful flags:
+
+- `--dry-run`: show Canvas actions without writing when `--publish` is used
+- `--page-title`: override published page title
+- `--module-name`: module to place schedule page link in (default: `Course Schedule`)
+- `--publish-weekly-slides`: create/reuse `Week XX` modules and add slide URL links
+- `--weekly-module-template`: override week module naming (default from plan: `Week {week_number}`)
+
+Plan hint:
+
+- Set `sync.topics_per_meeting: 2` (or higher) when a single class session covers multiple topic blocks.
+- Set `duration_hours` on a topic when it needs extra in-class time (for example `duration_hours: 3`).
+- Use reusable placeholders to insert spacer blocks without redefining `tbd-*` topics each term.
+- Define `resource_defaults.lecture_slides_base_url` to avoid repeating full slide URLs in each topic.
+
+Example:
+
+```yaml
+resource_defaults:
+  lecture_slides_base_url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+
+topics:
+  - id: process-scheduling-os7
+    lecture_slides:
+      - OSTEP 07.pdf
+```
+
+Reusable placeholder example:
+
+```yaml
+placeholders:
+  tbd:
+    title: Buffer / TBD
+    new_material: false
+
+topics:
+  - id: mlfq
+    duration_hours: 3
+  - placeholder: tbd
+    duration_hours: 1
+```
+
+Validate a plan file against the schema:
+
+```bash
+python scripts/validate_course_plan.py course_plans/cst334_compact.yaml
+```
+
 ## Parallel Uploads
 
 Question uploads support multi-threading to speed up large quizzes. The default

--- a/course_plans/cst334_compact.yaml
+++ b/course_plans/cst334_compact.yaml
@@ -1,0 +1,377 @@
+version: '1.1'
+term:
+  start_date: '2026-01-19'
+  end_date: '2026-05-07'
+  timezone: America/Los_Angeles
+  global_no_class_dates:
+  - '2026-01-21'
+  - '2026-01-22'
+  - '2026-03-30'
+  - '2026-03-31'
+  breaks:
+  - name: Break week 11
+    kind: break
+    start_date: '2026-03-30'
+    end_date: '2026-04-02'
+sections:
+- id: sec_mw
+  name: Mon/Wed
+  meeting_days:
+  - Mon
+  - Wed
+- id: sec_tth
+  name: Tue/Thu
+  meeting_days:
+  - Tue
+  - Thu
+sync:
+  mode: lockstep_by_topic
+  skip_for_all_if_any_section_skips: true
+  carry_over_policy: defer_topic
+  topics_per_meeting: 2
+  
+topics:
+
+## Exam 1 ##
+- id: course-intro
+  title: Course Intro
+  lecture_slides:
+  - 01a - introduction.pdf
+- id: os-intro
+  title: OS Intro (OS 2)
+  lecture_slides:
+  - 01a - introduction.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/intro.pdf
+- id: c-programming-1
+  title: C programming 1
+  duration_hours: 2
+  lecture_slides:
+  - 02a-c.pdf
+- id: computer-architecture
+  title: computer architecture
+  lecture_slides:
+  - 03a-6comp-arch.pdf
+- id: linux-and-shell
+  title: Linux and shell
+  lecture_slides:
+  - 03b-7linux-and-shell.pdf
+- id: processes
+  title: processes (OS 4)
+  lecture_slides:
+  - OSTEP 04  - processes.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/cpu-intro.pdf
+- id: c-process-api
+  title: C process API (OS 5)
+  lecture_slides:
+  - OSTEP 05 - C-process-api.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/cpu-api.pdf
+- id: limited-direct-execution
+  title: limited direct execution (OS 6)
+  lecture_slides:
+  - OSTEP 06 - limited-direct-execution.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/cpu-mechanisms.pdf
+- id: process-scheduling
+  title: process scheduling (OS 7)
+  duration_hours: 2
+  lecture_slides:
+  - OSTEP 07 - process-scheduling.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/cpu-sched.pdf
+- id: multi-level-feedback-queue
+  title: multi-level feedback queue (OS 8)
+  duration_hours: 2
+  lecture_slides:
+  - OSTEP 08 - multi-level-feedback-queue.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/cpu-sched-mlfq.pdf
+- placeholder: tbd
+
+## Exam 2 ##
+- id: address-spaces
+  title: address spaces (OS 13)
+  lecture_slides:
+  - OSTEP 13 - address-spaces.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/vm-intro.pdf
+- id: c-memory-api
+  title: C memory API (OS 14)
+  lecture_slides:
+  - OSTEP 14 - C-memory-api.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/vm-api.pdf
+- id: address-translation
+  title: address translation (OS 15)
+  lecture_slides:
+  - OSTEP 15 - 18-address-translation.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/vm-mechanism.pdf
+- id: segmentation
+  title: segmentation (OS 16)
+  lecture_slides:
+  - OSTEP 16 - 19-segmentation.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/vm-segmentation.pdf
+- id: paging
+  title: paging (OS 18)
+  lecture_slides:
+  - OSTEP 18 - 20-paging.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/vm-paging.pdf
+- id: translation-lookaside-buffers
+  title: translation-lookaside buffers (OS 19)
+  lecture_slides:
+  - OSTEP 19 - 21-trans-lookaside-buffer.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/vm-tlbs.pdf
+- id: page-directories
+  title: page directories (OS 20)
+  lecture_slides:
+  - OSTEP 20 - 22-multi-level-paging.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/vm-smalltables.pdf
+- id: swapping-mechanisms
+  title: 'swapping: mechanisms (OS 21)'
+  lecture_slides:
+  - OSTEP 21-22 - 23-swapping.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/vm-beyondphys.pdf
+- id: swapping-policies
+  title: 'swapping: policies (OS 22)'
+  lecture_slides:
+  - OSTEP 21-22 - 23-swapping.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/vm-beyondphys-policy.pdf
+- id: free-space-mgmt
+  title: free-space mgmt (OS 17)
+  lecture_slides:
+  - OSTEP 17 - 17-free-space-mgmt.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/vm-freespace.pdf
+  
+  
+- id: threads
+  title: threads (OS 26)
+  lecture_slides:
+  - OSTEP 26 - concurrency-and-threads.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/threads-intro.pdf
+- id: c-threads-api
+  title: C threads API (OS 27)
+  lecture_slides:
+  - OSTEP 27 - 36 - threads-api.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/threads-api.pdf
+- id: locks
+  title: locks (OS 28)
+  lecture_slides:
+  - OSTEP 28 - 37 - locks.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/threads-locks.pdf
+- id: locked-data-structures
+  title: locked data structures (OS 29)
+  lecture_slides:
+  - OSTEP 29 - 38 - lock-based-data-structures.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/threads-locks-usage.pdf
+- id: condition-variables
+  title: condition variables (OS 30)
+  lecture_slides:
+  - OSTEP 30 - 39 - condition-variables.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/threads-cv.pdf
+- id: semaphores
+  title: Semaphores (OS 31)
+  lecture_slides:
+  - OSTEP 31 - 41 - semaphores.pdf
+  - OSTEP 31a - sync-barrier-part1.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/threads-sema.pdf
+- id: anderson-dahlin
+  title: Anderson/Dahlin
+  duration_hours: 2
+  lecture_slides:
+  - Anderson Dahlin.pdf
+  
+- id: i-o-devices
+  title: I/O devices (OS 36)
+  lecture_slides:
+  - OSTEP 36 - 24-io-devices.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/file-devices.pdf
+- id: hard-disk-drives
+  title: hard disk drives (OS 37)
+  lecture_slides:
+  - OSTEP 37.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/file-disks.pdf
+- id: files-and-directories
+  title: files and directories (OS 39)
+  lecture_slides:
+  - OSTEP 39 - 25 - files-and-directories.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/file-intro.pdf
+  
+- id: file-system-implementation-i
+  title: file system implementation I (OS 40)
+  lecture_slides:
+  - OSTEP 40a - 26file-systems-impl-data.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/file-implementation.pdf
+- id: file-system-implementation-ii
+  title: file system implementation II (OS 40)
+  lecture_slides:
+  - OSTEP 40b - 27-file-systems-impl-access.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/file-implementation.pdf
+  
+  
+  
+- id: languages-bnf-grammars
+  title: 'Languages: BNF grammars'
+  lecture_slides:
+  - languages - 1 - BNF.pdf
+- id: languages-lexical-analysis
+  title: 'Languages: lexical analysis'
+  lecture_slides:
+  - languages - 2 - lexical-analysis.pdf
+- id: languages-predictive-parsing
+  title: 'Languages: predictive parsing'
+  lecture_slides:
+  - languages - 3 - predictive-parsing-1.pdf
+  - languages - 4 - predictive-parsing-2.pdf
+- id: languages-compilers-and-interpreters
+  title: 'Languages: compilers and interpreters'
+  lecture_slides:
+  - languages - 5 - compilers-and-interpreters.pdf
+  
+- id: intro-to-security
+  title: Intro to Security (OS 53)
+  lecture_slides:
+  - OSTEP 53 - Security Intro.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/security-intro.pdf
+- id: authentication
+  title: Authentication (OS 54)
+  lecture_slides:
+  - OSTEP 54 - authentication.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/security-authentication.pdf
+- id: access-control
+  title: Access Control (OS 55)
+  lecture_slides:
+  - OSTEP 55.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/security-access.pdf
+- id: cryptography
+  title: Cryptography (OS 56)
+  lecture_slides:
+  - OSTEP 56 - cryptography.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/security-crypto.pdf
+- id: distributed-systems
+  title: Distributed Systems (OS 48)
+  lecture_slides:
+  - OSTEP 48.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/dist-intro.pdf
+- id: distributed-security
+  title: Distributed Security (OS 57)
+  lecture_slides:
+  - OSTEP 57.pdf
+  readings:
+  - https://pages.cs.wisc.edu/~remzi/OSTEP/security-distributed.pdf
+
+- placeholder: tbd
+- placeholder: tbd
+- placeholder: tbd
+- placeholder: tbd
+
+exam_rules:
+  schedule_mode: mixed
+  defaults:
+    class_meeting_index_in_week: 2
+    min_class_meetings_after_last_new_material: 1
+    prefer_before_break: true
+    require_before_break: false
+  groups:
+  - name: Exam 1
+    through_topic: bash-2
+    fixed_date_overrides:
+      sec_mw: '2026-02-18'
+      sec_tth: '2026-02-19'
+  - name: Exam 2
+    through_topic: swapping-policies
+    fixed_date_overrides:
+      sec_mw: '2026-03-18'
+      sec_tth: '2026-03-19'
+  - name: Exam 3
+    through_topic: files-and-directories
+    fixed_date_overrides:
+      sec_mw: '2026-04-15'
+      sec_tth: '2026-04-16'
+  - name: Exam 4
+    through_topic: tbd-4
+publishing:
+  module_name_template: Week {week_number}
+  schedule_page_title: CST334 Schedule
+  create_calendar_html: true
+exam_coverage:
+  Exam 1:
+  - course-intro
+  - os-intro
+  - c-programming-1
+  - c-programming-2
+  - computer-architecture
+  - linux-and-shell
+  - processes
+  - c-process-api
+  - limited-direct-execution
+  - process-scheduling
+  - multi-level-feedback-queue
+  Exam 2:
+  - address-spaces
+  - c-memory-api
+  - free-space-mgmt
+  - address-translation
+  - segmentation
+  - paging
+  - translation-lookaside-buffers
+  - page-directories
+  - swapping-mechanisms
+  - swapping-policies
+  Exam 3:
+  - threads
+  - c-threads-api
+  - locks
+  - locked-data-structures
+  - condition-variables
+  - semaphores
+  - anderson-dahlin
+  - i-o-devices
+  - hard-disk-drives
+  - files-and-directories
+  Exam 4:
+  - file-system-implementation-i
+  - file-system-implementation-ii
+  - languages-bnf-grammars
+  - languages-lexical-analysis
+  - languages-predictive-parsing
+  - languages-compilers-and-interpreters
+  - tbd-2
+  - tbd-3
+  - intro-to-security
+  - authentication
+  - access-control
+  - cryptography
+  - distributed-systems
+  - distributed-security
+resource_defaults:
+  lecture_slides_base_url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+placeholders:
+  tbd:
+    title: TBD
+    new_material: false

--- a/course_plans/cst334_compact.yaml
+++ b/course_plans/cst334_compact.yaml
@@ -315,6 +315,9 @@ exam_rules:
       sec_tth: '2026-04-16'
   - name: Exam 4
     through_topic: tbd-4
+    fixed_date_overrides:
+      sec_tth: '2026-05-12'
+      sec_mw: '2026-05-13'
 publishing:
   module_name_template: Week {week_number}
   schedule_page_title: CST334 Schedule

--- a/course_plans/cst334_compact.yaml
+++ b/course_plans/cst334_compact.yaml
@@ -13,23 +13,40 @@ term:
     kind: break
     start_date: '2026-03-30'
     end_date: '2026-04-02'
+
 sections:
 - id: sec_mw
   name: Mon/Wed
-  meeting_days:
-  - Mon
-  - Wed
+  meeting_days: [Mon, Wed]
+  meeting_start_time: "10:00"
+  canvas_section_selector: "01"
+
 - id: sec_tth
   name: Tue/Thu
-  meeting_days:
-  - Tue
-  - Thu
+  meeting_days: [Tue, Thu]
+  meeting_start_time: "12:00"
+  canvas_section_selector: "02"
+  
 sync:
   mode: lockstep_by_topic
   skip_for_all_if_any_section_skips: true
   carry_over_policy: defer_topic
   topics_per_meeting: 2
   
+publishing:
+  module_name_template: Week {week_number}
+  schedule_page_title: CST334 Schedule
+  create_calendar_html: true
+  
+  attendance:
+    enabled: true
+    assignment_group_name: Attendance
+    title_prefix: "Attendance: "
+    unlock_minutes_before_start: 10
+    due_minutes_after_start: 10
+    lock_minutes_after_start: 10
+    include_exam_days: false
+    
 topics:
 
 ## Exam 1 ##
@@ -74,6 +91,7 @@ topics:
   - OSTEP 06 - limited-direct-execution.pdf
   readings:
   - https://pages.cs.wisc.edu/~remzi/OSTEP/cpu-mechanisms.pdf
+- placeholder: tbd
 - id: process-scheduling
   title: process scheduling (OS 7)
   duration_hours: 2
@@ -88,7 +106,6 @@ topics:
   - OSTEP 08 - multi-level-feedback-queue.pdf
   readings:
   - https://pages.cs.wisc.edu/~remzi/OSTEP/cpu-sched-mlfq.pdf
-- placeholder: tbd
 
 ## Exam 2 ##
 - id: address-spaces
@@ -318,10 +335,8 @@ exam_rules:
     fixed_date_overrides:
       sec_tth: '2026-05-12'
       sec_mw: '2026-05-13'
-publishing:
-  module_name_template: Week {week_number}
-  schedule_page_title: CST334 Schedule
-  create_calendar_html: true
+      
+      
 exam_coverage:
   Exam 1:
   - course-intro

--- a/course_plans/cst334_compact.yaml
+++ b/course_plans/cst334_compact.yaml
@@ -46,7 +46,70 @@ publishing:
     due_minutes_after_start: 10
     lock_minutes_after_start: 10
     include_exam_days: false
-    
+
+
+assignments:
+- id: weekly-notes
+  type: weekly_study_notes
+  title_template: "Weekly Study Notes {week_number:02d}"
+  assignment_group_name: "Learning Logs"
+  points_possible: 10
+  submission_types: ["online_text_entry"]
+  published: true
+  contents:
+    markdown: |
+      # How to Write Your Weekly Study Notes
+      ## Instructions
+      Your goal is to create notes that will actually help you study later. A good approach:
+      1. List the major topics/concepts covered this week (e.g., "process scheduling," "round-robin algorithm," "context switching")
+      2. For each topic, write a brief explanation that includes:
+        - What it is and why it matters
+        - How it connects to other concepts
+        - An example or key detail that helps you remember it
+      3. Flag anything unclear: Note topics you want to revisit or questions you still have
+
+      ## Example:
+      - Topic: Round-robin scheduling
+        - Explanation: CPU scheduling algorithm where each process gets equal time slice. Prevents starvation but can cause lots of context switches if time quantum is too small. Related to how the OS balances fairness vs. efficiency.
+      - Key detail: Time quantum typically 10-100ms
+      
+      ## Final Notes:
+      - There is a minimum of 250 words for these study notes, which shouldn't be too hard to hit.  Focus on clarity and organization that length.
+      - Submissions should be text typed into the textbox on canvas.  Pictures of handwritten study notes and links to google documents will not be accepted. 
+  rules:
+    include_exam_days: false
+    include_exam_only_weeks: false
+    unlock_time: "00:00"
+    due_anchor: "week_last_class"
+    due_days_after: 0
+    due_time: "23:59"
+    lock_days_after_due: 0
+    lock_time: "23:59"
+
+- id: pa
+  type: programming_assignment
+  title_template: "PA {instance_index}"
+  assignment_group_name: "Programming Assignments"
+  points_possible: 100
+  submission_types: ["online_upload"]
+  published: true
+  contents:
+    markdown: |
+      # Programming Assignment {instance_index}
+      See repo instructions.
+  rules:
+    instances:
+    - id: PA1
+      repo_path: PA1
+      release: {week: 2, day: 2, time: "12:00"}
+      due:
+        strategy: recommended
+        min_days_after_release: 13
+        preferred_weekday: Sun
+        include_exam_days: false
+        time: "23:59"
+
+
 topics:
 
 ## Exam 1 ##

--- a/course_plans/cst334_from_sheet.yaml
+++ b/course_plans/cst334_from_sheet.yaml
@@ -1,0 +1,646 @@
+version: '1.0'
+term:
+  start_date: '2026-01-19'
+  end_date: '2026-05-07'
+  timezone: America/Los_Angeles
+  global_no_class_dates:
+  - '2026-01-21'
+  - '2026-01-22'
+  - '2026-03-30'
+  - '2026-03-31'
+  breaks:
+  - name: Break week 11
+    kind: break
+    start_date: '2026-03-30'
+    end_date: '2026-04-02'
+sections:
+- id: sec_mw
+  name: Mon/Wed
+  meeting_days:
+  - Mon
+  - Wed
+- id: sec_tth
+  name: Tue/Thu
+  meeting_days:
+  - Tue
+  - Thu
+sync:
+  mode: lockstep_by_topic
+  skip_for_all_if_any_section_skips: true
+  carry_over_policy: defer_topic
+  topics_per_meeting: 2
+topics:
+- id: course-intro
+  title: Course Intro
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 1
+- id: os-intro
+  title: OS Intro (OS 2)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 02.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2002.pdf
+  readings:
+  - title: 'OSTEP chapter 2 (source label: OS 2)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 1
+- id: c-programming-1
+  title: C programming 1
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 1
+- id: c-programming-2
+  title: C programming 2
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 1
+- id: computer-architecture
+  title: computer architecture
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 1
+- id: linux-and-shell
+  title: Linux and shell
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 1
+- id: processes
+  title: processes (OS 4)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 04.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2004.pdf
+  readings:
+  - title: 'OSTEP chapter 4 (source label: OS 4)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 1
+- id: c-process-api
+  title: C process API (OS 5)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 05.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2005.pdf
+  readings:
+  - title: 'OSTEP chapter 5 (source label: OS 5)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 1
+- id: limited-direct-execution
+  title: limited direct execution (OS 6)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 06.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2006.pdf
+  readings:
+  - title: 'OSTEP chapter 6 (source label: OS 6)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 1
+- id: process-scheduling
+  title: process scheduling (OS 7)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 07.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2007.pdf
+  readings:
+  - title: 'OSTEP chapter 7 (source label: OS 7)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 1
+- id: multi-level-feedback-queue
+  title: multi-level feedback queue (OS 8)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 08.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2008.pdf
+  readings:
+  - title: 'OSTEP chapter 8 (source label: OS 8)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 1
+- id: tbd
+  title: TBD
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  new_material: false
+  tags:
+  - tbd
+  appears_on:
+  - Exam 1
+- id: bash
+  title: bash
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 1
+- id: bash-2
+  title: bash
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 1
+- id: address-spaces
+  title: address spaces (OS 13)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 13.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2013.pdf
+  readings:
+  - title: 'OSTEP chapter 13 (source label: OS 13)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 2
+- id: c-memory-api
+  title: C memory API (OS 14)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 14.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2014.pdf
+  readings:
+  - title: 'OSTEP chapter 14 (source label: OS 14)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 2
+- id: free-space-mgmt
+  title: free-space mgmt (OS 17)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 17.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2017.pdf
+  readings:
+  - title: 'OSTEP chapter 17 (source label: OS 17)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 2
+- id: address-translation
+  title: address translation (OS 15)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 15.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2015.pdf
+  readings:
+  - title: 'OSTEP chapter 15 (source label: OS 15)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 2
+- id: segmentation
+  title: segmentation (OS 16)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 16.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2016.pdf
+  readings:
+  - title: 'OSTEP chapter 16 (source label: OS 16)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 2
+- id: paging
+  title: paging (OS 18)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 18.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2018.pdf
+  readings:
+  - title: 'OSTEP chapter 18 (source label: OS 18)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 2
+- id: translation-lookaside-buffers
+  title: translation-lookaside buffers (OS 19)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 19.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2019.pdf
+  readings:
+  - title: 'OSTEP chapter 19 (source label: OS 19)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 2
+- id: page-directories
+  title: page directories (OS 20)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 20.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2020.pdf
+  readings:
+  - title: 'OSTEP chapter 20 (source label: OS 20)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 2
+- id: swapping-mechanisms
+  title: 'swapping: mechanisms (OS 21)'
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 21.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2021.pdf
+  readings:
+  - title: 'OSTEP chapter 21 (source label: OS 21)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 2
+- id: swapping-policies
+  title: 'swapping: policies (OS 22)'
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 22.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2022.pdf
+  readings:
+  - title: 'OSTEP chapter 22 (source label: OS 22)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 2
+- id: threads
+  title: threads (OS 26)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 26.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2026.pdf
+  readings:
+  - title: 'OSTEP chapter 26 (source label: OS 26)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 3
+- id: c-threads-api
+  title: C threads API (OS 27)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 27.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2027.pdf
+  readings:
+  - title: 'OSTEP chapter 27 (source label: OS 27)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 3
+- id: locks
+  title: locks (OS 28)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 28.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2028.pdf
+  readings:
+  - title: 'OSTEP chapter 28 (source label: OS 28)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 3
+- id: locked-data-structures
+  title: locked data structures (OS 29)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 29.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2029.pdf
+  readings:
+  - title: 'OSTEP chapter 29 (source label: OS 29)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 3
+- id: condition-variables
+  title: condition variables (OS 30)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 30.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2030.pdf
+  readings:
+  - title: 'OSTEP chapter 30 (source label: OS 30)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 3
+- id: semaphores
+  title: Semaphores (OS 31)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 31.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2031.pdf
+  readings:
+  - title: 'OSTEP chapter 31 (source label: OS 31)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 3
+- id: anderson-dahlin
+  title: Anderson/Dahlin
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 3
+- id: i-o-devices
+  title: I/O devices (OS 36)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 36.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2036.pdf
+  readings:
+  - title: 'OSTEP chapter 36 (source label: OS 36)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 3
+- id: hard-disk-drives
+  title: hard disk drives (OS 37)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 37.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2037.pdf
+  readings:
+  - title: 'OSTEP chapter 37 (source label: OS 37)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 3
+- id: files-and-directories
+  title: files and directories (OS 39)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 39.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2039.pdf
+  readings:
+  - title: 'OSTEP chapter 39 (source label: OS 39)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 3
+- id: file-system-implementation-i
+  title: file system implementation I (OS 40)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 40.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2040.pdf
+  readings:
+  - title: 'OSTEP chapter 40 (source label: OS 40)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 4
+- id: file-system-implementation-ii
+  title: file system implementation II (OS 40)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 40.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2040.pdf
+  readings:
+  - title: 'OSTEP chapter 40 (source label: OS 40)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 4
+- id: languages-bnf-grammars
+  title: 'Languages: BNF grammars'
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 4
+- id: languages-lexical-analysis
+  title: 'Languages: lexical analysis'
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 4
+- id: languages-predictive-parsing
+  title: 'Languages: predictive parsing'
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 4
+- id: languages-compilers-and-interpreters
+  title: 'Languages: compilers and interpreters'
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  appears_on:
+  - Exam 4
+- id: tbd-2
+  title: TBD
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  new_material: false
+  tags:
+  - tbd
+  appears_on:
+  - Exam 4
+- id: tbd-3
+  title: TBD
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  new_material: false
+  tags:
+  - tbd
+  appears_on:
+  - Exam 4
+- id: intro-to-security
+  title: Intro to Security (OS 53)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 53.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2053.pdf
+  readings:
+  - title: 'OSTEP chapter 53 (source label: OS 53)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 4
+- id: authentication
+  title: Authentication (OS 54)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 54.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2054.pdf
+  readings:
+  - title: 'OSTEP chapter 54 (source label: OS 54)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 4
+- id: access-control
+  title: Access Control (OS 55)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 55.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2055.pdf
+  readings:
+  - title: 'OSTEP chapter 55 (source label: OS 55)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 4
+- id: cryptography
+  title: Cryptography (OS 56)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 56.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2056.pdf
+  readings:
+  - title: 'OSTEP chapter 56 (source label: OS 56)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 4
+- id: distributed-systems
+  title: Distributed Systems (OS 48)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 48.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2048.pdf
+  readings:
+  - title: 'OSTEP chapter 48 (source label: OS 48)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 4
+- id: distributed-security
+  title: Distributed Security (OS 57)
+  lecture_slides:
+  - title: 'Placeholder slide: OSTEP 57.pdf'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2057.pdf
+  readings:
+  - title: 'OSTEP chapter 57 (source label: OS 57)'
+    type: reading
+    url: https://pages.cs.wisc.edu/~remzi/OSTEP/
+  appears_on:
+  - Exam 4
+- id: tbd-4
+  title: TBD
+  lecture_slides:
+  - title: 'TODO: add slide link'
+    type: lecture
+    required: false
+    url: https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs
+  new_material: false
+  tags:
+  - tbd
+  appears_on:
+  - Exam 4
+exam_rules:
+  schedule_mode: mixed
+  defaults:
+    class_meeting_index_in_week: 2
+    min_class_meetings_after_last_new_material: 1
+    prefer_before_break: true
+    require_before_break: false
+  groups:
+  - name: Exam 1
+    through_topic: bash-2
+    fixed_date_overrides:
+      sec_mw: '2026-02-18'
+      sec_tth: '2026-02-19'
+  - name: Exam 2
+    through_topic: swapping-policies
+    fixed_date_overrides:
+      sec_mw: '2026-03-18'
+      sec_tth: '2026-03-19'
+  - name: Exam 3
+    through_topic: files-and-directories
+    fixed_date_overrides:
+      sec_mw: '2026-04-15'
+      sec_tth: '2026-04-16'
+  - name: Exam 4
+    through_topic: tbd-4
+publishing:
+  module_name_template: Week {week_number}
+  schedule_page_title: CST334 Schedule
+  create_calendar_html: true

--- a/lms_interface/course_plan.py
+++ b/lms_interface/course_plan.py
@@ -1,0 +1,1479 @@
+from __future__ import annotations
+
+import copy
+import html
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, unquote, urljoin, urlparse, urlsplit, urlunsplit
+
+import canvasapi
+
+from lms_interface.canvas_interface import CanvasCourse
+
+log = logging.getLogger(__name__)
+
+WEEKDAY_TO_INT = {
+    "Mon": 0,
+    "Tue": 1,
+    "Wed": 2,
+    "Thu": 3,
+    "Fri": 4,
+    "Sat": 5,
+    "Sun": 6,
+}
+
+
+@dataclass
+class CalendarBuildResult:
+    normalized_plan: dict[str, Any]
+    calendar_json: dict[str, Any]
+    calendar_html: str
+    warnings: list[str]
+    output_paths: dict[str, Path]
+    publish_result: dict[str, Any] | None
+
+
+def _load_yaml_module():
+    try:
+        import yaml
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "PyYAML is required for course-plan workflows. "
+            "Install dependencies (e.g., `uv sync --dev`)."
+        ) from exc
+    return yaml
+
+
+def _parse_date(value: str | date) -> date:
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"Expected ISO date string, got: {value!r}")
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def _date_range(start: date, end: date) -> list[date]:
+    if end < start:
+        return []
+    days = (end - start).days
+    return [start + timedelta(days=i) for i in range(days + 1)]
+
+
+def _slugify(value: str) -> str:
+    s = value.strip().lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    return s.strip("-")
+
+
+def infer_title_from_id(topic_id: str) -> str:
+    text = topic_id.strip().replace("_", " ").replace("-", " ")
+    text = re.sub(r"\s+", " ", text)
+    tokens = text.split(" ")
+    normalized_tokens: list[str] = []
+    for token in tokens:
+        lower = token.lower()
+        if lower.startswith("ostep") and any(ch.isdigit() for ch in lower):
+            normalized_tokens.append(lower[:5].upper() + lower[5:])
+        elif token.isupper():
+            normalized_tokens.append(token)
+        else:
+            normalized_tokens.append(token.capitalize())
+    return " ".join(normalized_tokens).strip()
+
+
+def infer_resource_title(url: str) -> str:
+    parsed = urlparse(url)
+    leaf = unquote(parsed.path.rstrip("/").split("/")[-1]).strip()
+    if leaf:
+        return leaf
+    domain = parsed.netloc or "resource"
+    return domain
+
+
+def _canonicalize_http_url(url_value: str) -> str:
+    parsed = urlsplit(url_value)
+    if parsed.scheme not in {"http", "https"}:
+        return url_value
+    path = quote(unquote(parsed.path), safe="/:@!$&'()*+,;=-._~")
+    query = quote(unquote(parsed.query), safe="=&:@!$'()*+,;/?-._~")
+    fragment = quote(unquote(parsed.fragment), safe="=&:@!$'()*+,;/?-._~")
+    return urlunsplit((parsed.scheme, parsed.netloc, path, query, fragment))
+
+
+def _resolve_resource_url(url_value: str, *, base_url: str | None) -> str:
+    parsed = urlparse(url_value)
+    if parsed.scheme in {"http", "https"}:
+        return _canonicalize_http_url(url_value)
+    if base_url:
+        joined = urljoin(base_url.rstrip("/") + "/", url_value.lstrip("/"))
+        return _canonicalize_http_url(joined)
+    return url_value
+
+
+def _normalize_resource_list(
+    values: Any,
+    *,
+    base_url: str | None = None,
+) -> list[dict[str, Any]]:
+    if not values:
+        return []
+    normalized: list[dict[str, Any]] = []
+    for item in values:
+        if isinstance(item, str):
+            resolved_url = _resolve_resource_url(item, base_url=base_url)
+            normalized.append(
+                {
+                    "title": infer_resource_title(resolved_url),
+                    "url": resolved_url,
+                }
+            )
+            continue
+        if not isinstance(item, dict):
+            raise ValueError(f"Invalid resource item: {item!r}")
+        url = item.get("url")
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError(f"Resource is missing a valid url: {item!r}")
+        resolved_url = _resolve_resource_url(url, base_url=base_url)
+        entry: dict[str, Any] = {
+            "title": item.get("title") or infer_resource_title(resolved_url),
+            "url": resolved_url,
+        }
+        if "type" in item:
+            entry["type"] = item["type"]
+        if "required" in item:
+            entry["required"] = bool(item["required"])
+        normalized.append(entry)
+    return normalized
+
+
+def load_course_plan(plan_path: str | Path) -> dict[str, Any]:
+    yaml = _load_yaml_module()
+    raw = yaml.safe_load(Path(plan_path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("Course plan must be a mapping/object at the top level.")
+    return raw
+
+
+def normalize_course_plan(raw_plan: dict[str, Any]) -> dict[str, Any]:
+    plan = copy.deepcopy(raw_plan)
+
+    term_raw = plan.get("term") or {}
+    term_start = _parse_date(term_raw["start_date"])
+    term_end = _parse_date(term_raw["end_date"])
+    global_no_class_dates = {
+        _parse_date(value) for value in term_raw.get("global_no_class_dates", [])
+    }
+
+    breaks: list[dict[str, Any]] = []
+    for break_raw in term_raw.get("breaks", []):
+        applies_to = break_raw.get("applies_to")
+        breaks.append(
+            {
+                "name": break_raw.get("name", "Break"),
+                "kind": break_raw.get("kind", "break"),
+                "start_date": _parse_date(break_raw["start_date"]),
+                "end_date": _parse_date(break_raw["end_date"]),
+                "applies_to": set(applies_to) if applies_to else None,
+                "notes": break_raw.get("notes"),
+            }
+        )
+
+    sections: list[dict[str, Any]] = []
+    for section_raw in plan.get("sections", []):
+        day_values = section_raw.get("meeting_days", [])
+        meeting_days = [WEEKDAY_TO_INT[value] for value in day_values]
+        sections.append(
+            {
+                "id": section_raw["id"],
+                "name": section_raw.get("name", section_raw["id"]),
+                "meeting_days": sorted(set(meeting_days)),
+                "meeting_day_labels": day_values,
+                "canvas_course_id": section_raw.get("canvas_course_id"),
+            }
+        )
+
+    exam_coverage: dict[str, list[str]] = {}
+    raw_exam_coverage = plan.get("exam_coverage", {}) or {}
+    for exam_name, topic_ids in raw_exam_coverage.items():
+        exam_coverage[exam_name] = list(topic_ids)
+
+    resource_defaults_raw = plan.get("resource_defaults") or {}
+    resource_defaults = {
+        "lecture_slides_base_url": resource_defaults_raw.get("lecture_slides_base_url"),
+        "readings_base_url": resource_defaults_raw.get("readings_base_url"),
+        "resources_base_url": resource_defaults_raw.get("resources_base_url"),
+    }
+
+    placeholders_raw = plan.get("placeholders") or {}
+    if not isinstance(placeholders_raw, dict):
+        raise ValueError("`placeholders` must be a mapping when provided.")
+
+    used_topic_ids: dict[str, int] = {}
+    placeholder_counters: dict[str, int] = {}
+
+    topics: list[dict[str, Any]] = []
+    for topic_raw in plan.get("topics", []):
+        working_topic = copy.deepcopy(topic_raw)
+
+        placeholder_key = working_topic.pop("placeholder", None)
+        if placeholder_key:
+            template = placeholders_raw.get(placeholder_key)
+            if not isinstance(template, dict):
+                raise ValueError(
+                    f"Topic placeholder '{placeholder_key}' is not defined in top-level `placeholders`."
+                )
+            merged_topic = copy.deepcopy(template)
+            merged_topic.update(working_topic)
+            working_topic = merged_topic
+            if "id" not in working_topic:
+                placeholder_slug = _slugify(str(placeholder_key))
+                placeholder_counters[placeholder_slug] = (
+                    placeholder_counters.get(placeholder_slug, 0) + 1
+                )
+                working_topic["id"] = (
+                    f"{placeholder_slug}-{placeholder_counters[placeholder_slug]}"
+                )
+
+        topic_id = str(working_topic.get("id") or "").strip()
+        if not topic_id:
+            title_value = str(working_topic.get("title") or "").strip()
+            if not title_value:
+                raise ValueError("Each topic requires either `id` or `title`.")
+            topic_id = _slugify(title_value)
+        used_topic_ids[topic_id] = used_topic_ids.get(topic_id, 0) + 1
+        if used_topic_ids[topic_id] > 1:
+            topic_id = f"{topic_id}-{used_topic_ids[topic_id]}"
+
+        title = working_topic.get("title") or infer_title_from_id(topic_id)
+        meetings = int(working_topic.get("meetings", 1))
+        duration_hours = int(
+            working_topic.get("duration_hours", working_topic.get("hours", meetings))
+        )
+        topic = {
+            "id": topic_id,
+            "title": str(title).strip(),
+            "meetings": meetings,
+            "duration_hours": max(1, duration_hours),
+            "new_material": bool(working_topic.get("new_material", True)),
+            "lecture_slides": _normalize_resource_list(
+                working_topic.get("lecture_slides"),
+                base_url=resource_defaults.get("lecture_slides_base_url"),
+            ),
+            "readings": _normalize_resource_list(
+                working_topic.get("readings"),
+                base_url=resource_defaults.get("readings_base_url"),
+            ),
+            "resources": _normalize_resource_list(
+                working_topic.get("resources"),
+                base_url=resource_defaults.get("resources_base_url"),
+            ),
+            "notes": working_topic.get("notes"),
+            "tags": list(working_topic.get("tags", [])),
+        }
+        topics.append(topic)
+        for exam_name in working_topic.get("appears_on", []) or []:
+            exam_coverage.setdefault(exam_name, []).append(topic_id)
+
+    sync_raw = plan.get("sync") or {}
+    topics_per_meeting = int(
+        sync_raw.get("topics_per_meeting", sync_raw.get("hours_per_meeting", 1))
+    )
+    sync = {
+        "mode": sync_raw.get("mode", "lockstep_by_topic"),
+        "skip_for_all_if_any_section_skips": bool(
+            sync_raw.get("skip_for_all_if_any_section_skips", True)
+        ),
+        "carry_over_policy": sync_raw.get("carry_over_policy", "defer_topic"),
+        "topics_per_meeting": max(1, topics_per_meeting),
+        "hours_per_meeting": max(1, topics_per_meeting),
+    }
+
+    publishing_raw = plan.get("publishing") or {}
+    weekly_slides_indent = int(publishing_raw.get("weekly_slides_indent", 1))
+    publishing = {
+        "module_name_template": publishing_raw.get(
+            "module_name_template",
+            "Week {week_number}",
+        ),
+        "schedule_page_title": publishing_raw.get(
+            "schedule_page_title",
+            "Course Schedule",
+        ),
+        "create_calendar_html": bool(publishing_raw.get("create_calendar_html", True)),
+        "weekly_slides_title_prefix": str(
+            publishing_raw.get("weekly_slides_title_prefix", "Slides: ")
+        ),
+        "weekly_slides_indent": max(0, weekly_slides_indent),
+        "weekly_slides_section_header": (
+            str(publishing_raw["weekly_slides_section_header"]).strip()
+            if publishing_raw.get("weekly_slides_section_header") is not None
+            else "Slides"
+        ),
+        "weekly_slides_prune_existing": bool(
+            publishing_raw.get("weekly_slides_prune_existing", True)
+        ),
+    }
+
+    exam_rules_raw = plan.get("exam_rules") or {}
+    exam_defaults_raw = exam_rules_raw.get("defaults") or {}
+    exam_rules = {
+        "schedule_mode": exam_rules_raw.get("schedule_mode", "derived"),
+        "defaults": {
+            "class_meeting_index_in_week": int(
+                exam_defaults_raw.get("class_meeting_index_in_week", 2)
+            ),
+            "min_class_meetings_after_last_new_material": int(
+                exam_defaults_raw.get("min_class_meetings_after_last_new_material", 1)
+            ),
+            "prefer_before_break": bool(
+                exam_defaults_raw.get("prefer_before_break", True)
+            ),
+            "require_before_break": bool(
+                exam_defaults_raw.get("require_before_break", False)
+            ),
+        },
+        "groups": list(exam_rules_raw.get("groups", [])),
+    }
+
+    return {
+        "version": str(plan.get("version", "1.1")),
+        "term": {
+            "start_date": term_start,
+            "end_date": term_end,
+            "timezone": term_raw.get("timezone", "America/Los_Angeles"),
+            "global_no_class_dates": global_no_class_dates,
+            "breaks": breaks,
+        },
+        "sections": sections,
+        "sync": sync,
+        "topics": topics,
+        "placeholders": placeholders_raw,
+        "exam_rules": exam_rules,
+        "exam_coverage": exam_coverage,
+        "resource_defaults": resource_defaults,
+        "publishing": publishing,
+    }
+
+
+def _blocked_dates_for_section(term: dict[str, Any], section_id: str) -> set[date]:
+    blocked = set(term["global_no_class_dates"])
+    for break_period in term["breaks"]:
+        applies_to = break_period["applies_to"]
+        if applies_to and section_id not in applies_to:
+            continue
+        blocked.update(
+            _date_range(break_period["start_date"], break_period["end_date"])
+        )
+    return blocked
+
+
+def _section_slots(plan: dict[str, Any]) -> dict[str, dict[tuple[date, int], date]]:
+    term = plan["term"]
+    start_date = term["start_date"]
+    end_date = term["end_date"]
+    slots_by_section: dict[str, dict[tuple[date, int], date]] = {}
+
+    for section in plan["sections"]:
+        section_id = section["id"]
+        blocked_dates = _blocked_dates_for_section(term, section_id)
+        meeting_days = set(section["meeting_days"])
+
+        weekly_dates: dict[date, list[date]] = {}
+        for day in _date_range(start_date, end_date):
+            if day.weekday() not in meeting_days:
+                continue
+            if day in blocked_dates:
+                continue
+            week_start = day - timedelta(days=day.weekday())
+            weekly_dates.setdefault(week_start, []).append(day)
+
+        section_slots: dict[tuple[date, int], date] = {}
+        for week_start, dates in weekly_dates.items():
+            for idx, meeting_date in enumerate(sorted(dates), start=1):
+                section_slots[(week_start, idx)] = meeting_date
+        slots_by_section[section_id] = section_slots
+
+    return slots_by_section
+
+
+def _next_break_start_after(term: dict[str, Any], pivot: date) -> date | None:
+    starts = []
+    for break_period in term["breaks"]:
+        start_date = break_period["start_date"]
+        if start_date > pivot:
+            starts.append(start_date)
+    return min(starts) if starts else None
+
+
+def _slot_index_for_section_date(
+    slots: list[dict[str, Any]],
+    *,
+    section_id: str,
+    meeting_date: date,
+) -> int | None:
+    for idx, slot in enumerate(slots):
+        if slot["dates"].get(section_id) == meeting_date:
+            return idx
+    return None
+
+
+def build_schedule(plan: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    warnings: list[str] = []
+    slots_by_section = _section_slots(plan)
+    sections = plan["sections"]
+    section_ids = [section["id"] for section in sections]
+    key_sets = [set(slots_by_section[sid].keys()) for sid in section_ids]
+
+    if not key_sets:
+        raise ValueError("At least one section is required.")
+
+    sync_mode = plan["sync"]["mode"]
+    skip_all = plan["sync"]["skip_for_all_if_any_section_skips"]
+    if sync_mode == "lockstep_by_topic":
+        if skip_all and len(key_sets) > 1:
+            selected_keys = set.intersection(*key_sets)
+        else:
+            selected_keys = set.union(*key_sets)
+    else:
+        selected_keys = key_sets[0]
+
+    sorted_keys = sorted(selected_keys, key=lambda key: (key[0], key[1]))
+    week_numbers: dict[date, int] = {}
+    for key in sorted_keys:
+        week_start = key[0]
+        if week_start not in week_numbers:
+            week_numbers[week_start] = len(week_numbers) + 1
+
+    slots: list[dict[str, Any]] = []
+    for key in sorted_keys:
+        week_start, slot_in_week = key
+        slot = {
+            "week_start": week_start,
+            "week_number": week_numbers[week_start],
+            "slot_in_week": slot_in_week,
+            "dates": {
+                section_id: slots_by_section[section_id].get(key)
+                for section_id in section_ids
+            },
+            "allocations": [],
+            "topic": None,
+        }
+        slots.append(slot)
+
+    hours_per_meeting = plan["sync"]["topics_per_meeting"]
+
+    exam_defaults = plan["exam_rules"]["defaults"]
+    exam_groups = list(plan["exam_rules"]["groups"])
+    if not exam_groups and plan["exam_coverage"]:
+        for exam_name, topics in plan["exam_coverage"].items():
+            if not topics:
+                continue
+            exam_groups.append(
+                {
+                    "name": exam_name,
+                    "included_topics": topics,
+                }
+            )
+
+    exam_warnings: list[str] = []
+    exam_dates: dict[str, dict[str, str]] = {}
+    exam_slots_by_name: dict[str, set[int]] = {}
+    blocked_slot_indices: set[int] = set()
+
+    for group in exam_groups:
+        name = str(group.get("name") or "").strip()
+        if not name:
+            continue
+        group_slots: set[int] = set()
+        section_exam_dates: dict[str, str] = {}
+        fixed_dates = group.get("fixed_date_overrides", {}) or {}
+        for section_id, raw_date in fixed_dates.items():
+            if section_id not in section_ids:
+                exam_warnings.append(
+                    f"Exam '{name}' has fixed_date_overrides for unknown section '{section_id}'."
+                )
+                continue
+            parsed_date = _parse_date(raw_date)
+            section_exam_dates[section_id] = parsed_date.isoformat()
+            slot_idx_for_date = _slot_index_for_section_date(
+                slots,
+                section_id=section_id,
+                meeting_date=parsed_date,
+            )
+            if slot_idx_for_date is not None:
+                group_slots.add(slot_idx_for_date)
+
+        if section_exam_dates:
+            exam_dates[name] = section_exam_dates
+        if group_slots:
+            exam_slots_by_name[name] = set(group_slots)
+            blocked_slot_indices.update(group_slots)
+
+    def _allocate_topics(
+        blocked_indices: set[int],
+    ) -> tuple[dict[str, int], list[str]]:
+        local_warnings: list[str] = []
+        topic_slot_index: dict[str, int] = {}
+        for slot in slots:
+            slot["allocations"] = []
+            slot["topic"] = None
+
+        slot_idx = 0
+        slot_hours_remaining = hours_per_meeting
+        for topic in plan["topics"]:
+            remaining_topic_hours = max(1, int(topic.get("duration_hours", 1)))
+            while remaining_topic_hours > 0:
+                while slot_idx < len(slots) and slot_idx in blocked_indices:
+                    slot_idx += 1
+                    slot_hours_remaining = hours_per_meeting
+
+                if slot_idx >= len(slots):
+                    local_warnings.append(
+                        f"Topic '{topic['id']}' did not fit in available meeting slots ({remaining_topic_hours}h unscheduled)."
+                    )
+                    break
+
+                allocation_hours = min(remaining_topic_hours, slot_hours_remaining)
+                slots[slot_idx]["allocations"].append(
+                    {
+                        "topic": topic,
+                        "hours": allocation_hours,
+                    }
+                )
+                slots[slot_idx]["topic"] = slots[slot_idx]["allocations"][0]["topic"]
+                topic_slot_index[topic["id"]] = slot_idx
+
+                remaining_topic_hours -= allocation_hours
+                slot_hours_remaining -= allocation_hours
+                if slot_hours_remaining == 0:
+                    slot_idx += 1
+                    slot_hours_remaining = hours_per_meeting
+
+        return topic_slot_index, local_warnings
+
+    topic_slot_index, allocation_warnings = _allocate_topics(blocked_slot_indices)
+
+    for group in exam_groups:
+        name = str(group.get("name") or "").strip()
+        if not name:
+            continue
+
+        section_exam_dates = dict(exam_dates.get(name, {}))
+        group_exam_slots = set(exam_slots_by_name.get(name, set()))
+        if len(section_exam_dates) < len(section_ids) and group_exam_slots:
+            anchor_slot = slots[min(group_exam_slots)]
+            for section_id in section_ids:
+                if section_id in section_exam_dates:
+                    continue
+                meeting_date = anchor_slot["dates"].get(section_id)
+                if meeting_date is not None:
+                    section_exam_dates[section_id] = meeting_date.isoformat()
+
+        coverage_topics = list(group.get("included_topics", []))
+        if not coverage_topics and name in plan["exam_coverage"]:
+            coverage_topics = list(plan["exam_coverage"][name])
+        through_topic = group.get("through_topic")
+        if through_topic:
+            coverage_topics.append(through_topic)
+
+        last_slot_index = None
+        for topic_id in coverage_topics:
+            slot_idx = topic_slot_index.get(topic_id)
+            if slot_idx is not None:
+                if last_slot_index is None or slot_idx > last_slot_index:
+                    last_slot_index = slot_idx
+
+        if len(section_exam_dates) < len(section_ids):
+            if last_slot_index is None:
+                exam_warnings.append(
+                    f"Exam '{name}' could not be derived (no through_topic/included_topics matched scheduled topics)."
+                )
+            else:
+                min_gap = int(
+                    group.get(
+                        "min_class_meetings_after_last_new_material",
+                        exam_defaults["min_class_meetings_after_last_new_material"],
+                    )
+                )
+                meeting_index = int(
+                    group.get(
+                        "class_meeting_index_in_week",
+                        exam_defaults["class_meeting_index_in_week"],
+                    )
+                )
+                earliest_idx = last_slot_index + min_gap + 1
+                candidate_indices = [
+                    idx
+                    for idx in range(earliest_idx, len(slots))
+                    if idx not in blocked_slot_indices
+                    if slots[idx]["slot_in_week"] == meeting_index
+                ]
+                if not candidate_indices:
+                    candidate_indices = [
+                        idx
+                        for idx in range(earliest_idx, len(slots))
+                        if idx not in blocked_slot_indices
+                    ]
+
+                prefer_before_break = bool(
+                    group.get(
+                        "prefer_before_break", exam_defaults["prefer_before_break"]
+                    )
+                )
+                require_before_break = bool(
+                    group.get(
+                        "require_before_break", exam_defaults["require_before_break"]
+                    )
+                )
+                if candidate_indices and (prefer_before_break or require_before_break):
+                    pivot_date = min(
+                        d
+                        for d in slots[last_slot_index]["dates"].values()
+                        if d is not None
+                    )
+                    next_break_start = _next_break_start_after(plan["term"], pivot_date)
+                    if next_break_start is not None:
+                        before_break = []
+                        for idx in candidate_indices:
+                            slot_dates = [
+                                d for d in slots[idx]["dates"].values() if d is not None
+                            ]
+                            if slot_dates and max(slot_dates) < next_break_start:
+                                before_break.append(idx)
+                        if before_break:
+                            candidate_indices = before_break
+                        elif require_before_break:
+                            exam_warnings.append(
+                                f"Exam '{name}' requires placement before break starting {next_break_start.isoformat()}, but no slot matched."
+                            )
+
+                if candidate_indices:
+                    chosen_idx = candidate_indices[0]
+                    chosen_slot = slots[chosen_idx]
+                    group_exam_slots.add(chosen_idx)
+                    for section_id in section_ids:
+                        if section_id in section_exam_dates:
+                            continue
+                        meeting_date = chosen_slot["dates"].get(section_id)
+                        if meeting_date is not None:
+                            section_exam_dates[section_id] = meeting_date.isoformat()
+                    if chosen_idx not in blocked_slot_indices:
+                        blocked_slot_indices.add(chosen_idx)
+                        topic_slot_index, allocation_warnings = _allocate_topics(
+                            blocked_slot_indices
+                        )
+                else:
+                    exam_warnings.append(
+                        f"Exam '{name}' could not be scheduled; no remaining candidate slots."
+                    )
+
+        if section_exam_dates:
+            exam_dates[name] = section_exam_dates
+        if group_exam_slots:
+            exam_slots_by_name[name] = group_exam_slots
+
+    warnings.extend(allocation_warnings)
+    warnings.extend(exam_warnings)
+
+    rows = []
+    slot_exam_lookup: dict[int, list[str]] = {}
+    for exam_name, slot_indices in exam_slots_by_name.items():
+        for idx in slot_indices:
+            slot_exam_lookup.setdefault(idx, []).append(exam_name)
+
+    for idx, slot in enumerate(slots):
+        allocations = slot.get("allocations", [])
+        primary_topic = allocations[0]["topic"] if allocations else None
+        exam_names = sorted(slot_exam_lookup.get(idx, []))
+        readings: list[dict[str, Any]] = []
+        lecture_slides: list[dict[str, Any]] = []
+        resources: list[dict[str, Any]] = []
+        topic_ids: list[str] = []
+        topic_titles: list[str] = []
+        topic_allocations: list[dict[str, Any]] = []
+        for allocation in allocations:
+            topic = allocation["topic"]
+            hours = int(allocation["hours"])
+            readings.extend(topic["readings"])
+            lecture_slides.extend(topic["lecture_slides"])
+            resources.extend(topic["resources"])
+            topic_ids.append(topic["id"])
+            label = topic["title"] if hours == 1 else f"{topic['title']} ({hours}h)"
+            topic_titles.append(label)
+            topic_allocations.append(
+                {
+                    "topic_id": topic["id"],
+                    "topic_title": topic["title"],
+                    "hours": hours,
+                }
+            )
+        rows.append(
+            {
+                "week_number": slot["week_number"],
+                "slot_in_week": slot["slot_in_week"],
+                "dates": {
+                    sid: value.isoformat() if value else None
+                    for sid, value in slot["dates"].items()
+                },
+                "topic_ids": topic_ids,
+                "topic_titles": topic_titles,
+                "topic_allocations": topic_allocations,
+                "topic_id": primary_topic["id"] if primary_topic else None,
+                "topic_title": primary_topic["title"] if primary_topic else None,
+                "exam_names": exam_names,
+                "readings": readings,
+                "lecture_slides": lecture_slides,
+                "resources": resources,
+                "new_material": any(
+                    bool(allocation["topic"]["new_material"])
+                    for allocation in allocations
+                ),
+            }
+        )
+
+    exams_with_slot_rows = {
+        exam_name for exam_names in slot_exam_lookup.values() for exam_name in exam_names
+    }
+    week_numbers_with_exams = dict(week_numbers)
+    next_week_number = len(week_numbers_with_exams) + 1
+    for exam_name, section_dates in exam_dates.items():
+        if exam_name in exams_with_slot_rows:
+            continue
+        parsed_dates: dict[str, date] = {}
+        for section_id, iso_date in section_dates.items():
+            try:
+                parsed_dates[section_id] = _parse_date(iso_date)
+            except Exception:
+                continue
+        if not parsed_dates:
+            continue
+
+        earliest_exam_date = min(parsed_dates.values())
+        exam_week_start = earliest_exam_date - timedelta(days=earliest_exam_date.weekday())
+        if exam_week_start not in week_numbers_with_exams:
+            week_numbers_with_exams[exam_week_start] = next_week_number
+            next_week_number += 1
+        rows.append(
+            {
+                "week_number": week_numbers_with_exams[exam_week_start],
+                "slot_in_week": "Exam",
+                "dates": {
+                    sid: section_dates.get(sid)
+                    for sid in section_ids
+                },
+                "topic_ids": [],
+                "topic_titles": [],
+                "topic_allocations": [],
+                "topic_id": None,
+                "topic_title": None,
+                "exam_names": [exam_name],
+                "readings": [],
+                "lecture_slides": [],
+                "resources": [],
+                "new_material": False,
+            }
+        )
+
+    rows.sort(
+        key=lambda row: (
+            int(row["week_number"]),
+            0 if isinstance(row.get("slot_in_week"), int) else 1,
+            row.get("slot_in_week"),
+        )
+    )
+
+    schedule = {
+        "sections": sections,
+        "rows": rows,
+        "exam_dates": exam_dates,
+        "term": {
+            "start_date": plan["term"]["start_date"].isoformat(),
+            "end_date": plan["term"]["end_date"].isoformat(),
+            "timezone": plan["term"]["timezone"],
+            "breaks": [
+                {
+                    "name": b["name"],
+                    "kind": b["kind"],
+                    "start_date": b["start_date"].isoformat(),
+                    "end_date": b["end_date"].isoformat(),
+                    "applies_to": (
+                        sorted(list(b["applies_to"])) if b["applies_to"] else None
+                    ),
+                }
+                for b in plan["term"]["breaks"]
+            ],
+        },
+    }
+    return schedule, warnings
+
+
+def _render_resource_links(resources: list[dict[str, Any]]) -> str:
+    if not resources:
+        return ""
+    links = []
+    for resource in resources:
+        label = html.escape(
+            str(resource.get("title") or infer_resource_title(resource["url"]))
+        )
+        href = html.escape(str(resource["url"]), quote=True)
+        links.append(
+            f'<a href="{href}" target="_blank" rel="noopener noreferrer">{label}</a>'
+        )
+    return "<br/>".join(links)
+
+
+def render_calendar_html(
+    normalized_plan: dict[str, Any],
+    calendar_json: dict[str, Any],
+) -> str:
+    section_columns = calendar_json["sections"]
+    exam_lookup: dict[tuple[str, str], list[str]] = {}
+    for exam_name, section_dates in calendar_json["exam_dates"].items():
+        for section_id, date_value in section_dates.items():
+            exam_lookup.setdefault((section_id, date_value), []).append(exam_name)
+
+    break_items = []
+    for break_period in calendar_json["term"]["breaks"]:
+        label = f"{break_period['name']}: {break_period['start_date']} to {break_period['end_date']}"
+        break_items.append(f"<li>{html.escape(label)}</li>")
+    break_html = (
+        "<ul>" + "".join(break_items) + "</ul>" if break_items else "<p>None</p>"
+    )
+
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+    page_title = html.escape(normalized_plan["publishing"]["schedule_page_title"])
+
+    rows_html = []
+    for row in calendar_json["rows"]:
+        titles = row.get("topic_titles") or []
+        exam_names = row.get("exam_names") or []
+        if titles:
+            topic_title = "<br/>".join(
+                f"<strong>{html.escape(title)}</strong>" for title in titles
+            )
+        elif exam_names:
+            topic_title = "<br/>".join(
+                f"<strong>{html.escape(f'Exam: {exam}')}</strong>"
+                for exam in exam_names
+            )
+        else:
+            topic_title = html.escape(row.get("topic_title") or "")
+        readings_html = _render_resource_links(row["readings"])
+        slides_html = _render_resource_links(row["lecture_slides"])
+        extra_html = _render_resource_links(row["resources"])
+        if not readings_html:
+            readings_html = "&nbsp;"
+        if not slides_html:
+            slides_html = "&nbsp;"
+        if not extra_html:
+            extra_html = "&nbsp;"
+
+        cells = [
+            f"<td>{row['week_number']}</td>",
+            f"<td>{row['slot_in_week']}</td>",
+            f"<td>{topic_title if topic_title else '&nbsp;'}</td>",
+            f"<td>{readings_html}</td>",
+            f"<td>{slides_html}</td>",
+            f"<td>{extra_html}</td>",
+        ]
+
+        for section in section_columns:
+            section_id = section["id"]
+            date_value = row["dates"].get(section_id)
+            if date_value:
+                label = date_value
+                exams = exam_lookup.get((section_id, date_value), [])
+                badges = " ".join(
+                    f'<span class="exam-badge">{html.escape(exam)}</span>'
+                    for exam in exams
+                )
+                cells.append(f"<td>{html.escape(label)} {badges}</td>")
+            else:
+                cells.append('<td class="muted">No class</td>')
+
+        rows_html.append("<tr>" + "".join(cells) + "</tr>")
+
+    section_headers = "".join(
+        f"<th>{html.escape(section['name'])}</th>" for section in section_columns
+    )
+
+    return f"""<!-- course-plan-generated:start -->
+<style>
+.course-calendar {{ font-family: Arial, sans-serif; font-size: 14px; }}
+.course-calendar table {{ border-collapse: collapse; width: 100%; }}
+.course-calendar th, .course-calendar td {{ border: 1px solid #ccc; padding: 8px; vertical-align: top; }}
+.course-calendar th {{ background: #f5f5f5; }}
+.course-calendar .muted {{ color: #777; }}
+.course-calendar .exam-badge {{
+  display: inline-block;
+  margin-left: 6px;
+  padding: 2px 6px;
+  background: #ffe8a3;
+  border: 1px solid #e0c34d;
+  border-radius: 4px;
+  font-size: 12px;
+}}
+</style>
+<div class="course-calendar">
+  <h2>{page_title}</h2>
+  <p><strong>Generated:</strong> {generated_at}</p>
+  <p><strong>Term:</strong> {calendar_json['term']['start_date']} to {calendar_json['term']['end_date']} ({html.escape(calendar_json['term']['timezone'])})</p>
+  <h3>Breaks</h3>
+  {break_html}
+  <h3>Schedule</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>Week</th>
+        <th>Slot</th>
+        <th>Topic</th>
+        <th>Readings</th>
+        <th>Slides</th>
+        <th>Other Resources</th>
+        {section_headers}
+      </tr>
+    </thead>
+    <tbody>
+      {''.join(rows_html)}
+    </tbody>
+  </table>
+</div>
+<!-- course-plan-generated:end -->
+"""
+
+
+def _find_page_by_title(canvas_course: CanvasCourse, title: str):
+    for page in canvas_course.course.get_pages():
+        if str(getattr(page, "title", "")).strip() == title.strip():
+            return page
+    return None
+
+
+def _find_module_by_name(canvas_course: CanvasCourse, module_name: str):
+    for module in canvas_course.course.get_modules():
+        if str(getattr(module, "name", "")).strip() == module_name.strip():
+            return module
+    return None
+
+
+def _build_weekly_slide_items(
+    calendar_json: dict[str, Any],
+    *,
+    module_name_template: str,
+) -> dict[str, list[dict[str, str]]]:
+    weekly: dict[str, list[dict[str, str]]] = {}
+    seen_by_module: dict[str, set[str]] = {}
+
+    for row in calendar_json.get("rows", []):
+        week_number = row.get("week_number")
+        try:
+            module_name = module_name_template.format(week_number=week_number)
+        except Exception:
+            module_name = f"Week {week_number}"
+        weekly.setdefault(module_name, [])
+        seen_by_module.setdefault(module_name, set())
+
+        for slide in row.get("lecture_slides", []) or []:
+            if not isinstance(slide, dict):
+                continue
+            url = str(slide.get("url") or "").strip()
+            if not url:
+                continue
+            if url in seen_by_module[module_name]:
+                continue
+            seen_by_module[module_name].add(url)
+            weekly[module_name].append(
+                {
+                    "title": str(slide.get("title") or infer_resource_title(url)),
+                    "url": url,
+                }
+            )
+    return weekly
+
+
+def publish_calendar_to_canvas(
+    canvas_course: CanvasCourse,
+    *,
+    calendar_json: dict[str, Any],
+    page_title: str,
+    module_name: str | None,
+    publish_weekly_slides: bool,
+    weekly_module_template: str,
+    weekly_slides_title_prefix: str,
+    weekly_slides_indent: int,
+    weekly_slides_section_header: str | None,
+    weekly_slides_prune_existing: bool,
+    lecture_slides_base_url: str | None,
+    html_body: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    actions: list[str] = []
+    page_url = _slugify(page_title)
+    normalized_title_prefix = str(weekly_slides_title_prefix or "")
+    normalized_weekly_indent = max(0, int(weekly_slides_indent))
+    normalized_lecture_base = (
+        _canonicalize_http_url(lecture_slides_base_url)
+        if lecture_slides_base_url
+        else None
+    )
+    section_header_value = (
+        str(weekly_slides_section_header).strip()
+        if weekly_slides_section_header is not None
+        else ""
+    )
+
+    def _ensure_module_published(module_obj: Any, *, module_label: str) -> None:
+        if bool(getattr(module_obj, "published", False)):
+            return
+        actions.append(f"publish-module:{module_label}")
+        log.info("Publishing module '%s'", module_label)
+        if not dry_run:
+            module_obj.edit(module={"published": True})
+
+    def _ensure_module_item_published(item_obj: Any, *, item_label: str) -> None:
+        if bool(getattr(item_obj, "published", False)):
+            return
+        actions.append(f"publish-module-item:{item_label}")
+        log.info("Publishing module item '%s'", item_label)
+        if not dry_run:
+            item_obj.edit(module_item={"published": True})
+
+    existing_page = _find_page_by_title(canvas_course, page_title)
+    if existing_page is not None:
+        actions.append(f"update-page:{page_title}")
+        page_url = getattr(existing_page, "url", page_url) or page_url
+        if not dry_run:
+            existing_page.edit(
+                wiki_page={
+                    "title": page_title,
+                    "body": html_body,
+                    "published": True,
+                }
+            )
+    else:
+        actions.append(f"create-page:{page_title}")
+        if not dry_run:
+            created_page = canvas_course.course.create_page(
+                wiki_page={
+                    "title": page_title,
+                    "body": html_body,
+                    "published": True,
+                }
+            )
+            page_url = getattr(created_page, "url", page_url) or page_url
+
+    if module_name:
+        module = _find_module_by_name(canvas_course, module_name)
+        if module is None:
+            actions.append(f"create-module:{module_name}")
+            if not dry_run:
+                module = canvas_course.course.create_module(
+                    module={
+                        "name": module_name,
+                        "published": True,
+                    }
+                )
+        else:
+            actions.append(f"reuse-module:{module_name}")
+
+        if module is not None:
+            _ensure_module_published(module, module_label=module_name)
+            page_item = None
+            for item in module.get_module_items():
+                item_type = str(getattr(item, "type", "")).lower()
+                item_title = str(getattr(item, "title", ""))
+                item_page_url = str(getattr(item, "page_url", ""))
+                if item_type == "page" and (
+                    item_page_url == page_url
+                    or item_title.strip() == page_title.strip()
+                ):
+                    page_item = item
+                    break
+            if page_item is None:
+                actions.append(f"link-page-in-module:{module_name}:{page_title}")
+                if not dry_run:
+                    page_item = module.create_module_item(
+                        module_item={
+                            "type": "Page",
+                            "title": page_title,
+                            "page_url": page_url,
+                            "published": True,
+                        }
+                    )
+                    _ensure_module_item_published(
+                        page_item,
+                        item_label=f"{module_name}:{page_title}",
+                    )
+            else:
+                actions.append(f"module-link-exists:{module_name}:{page_title}")
+                _ensure_module_item_published(
+                    page_item,
+                    item_label=f"{module_name}:{page_title}",
+                )
+
+    if publish_weekly_slides:
+        weekly_modules = _build_weekly_slide_items(
+            calendar_json,
+            module_name_template=weekly_module_template,
+        )
+        total_modules = len(weekly_modules)
+        for module_idx, (weekly_module_name, links) in enumerate(
+            weekly_modules.items(), start=1
+        ):
+            log.info(
+                "Weekly slides module %d/%d: %s (%d links)",
+                module_idx,
+                total_modules,
+                weekly_module_name,
+                len(links),
+            )
+            weekly_module = _find_module_by_name(canvas_course, weekly_module_name)
+            if weekly_module is None:
+                actions.append(f"create-module:{weekly_module_name}")
+                log.info("Creating module '%s'", weekly_module_name)
+                if not dry_run:
+                    weekly_module = canvas_course.course.create_module(
+                        module={
+                            "name": weekly_module_name,
+                            "published": True,
+                        }
+                    )
+            else:
+                actions.append(f"reuse-module:{weekly_module_name}")
+                log.info("Reusing module '%s'", weekly_module_name)
+
+            if weekly_module is not None:
+                _ensure_module_published(weekly_module, module_label=weekly_module_name)
+
+            desired_links: list[dict[str, str]] = []
+            desired_urls: set[str] = set()
+            for link in links:
+                raw_title = str(link.get("title") or "").strip()
+                raw_url = _canonicalize_http_url(str(link.get("url") or "").strip())
+                if not raw_url:
+                    continue
+                desired_title = (
+                    f"{normalized_title_prefix}{raw_title}"
+                    if normalized_title_prefix
+                    else raw_title
+                )
+                desired_links.append(
+                    {
+                        "title": desired_title,
+                        "url": raw_url,
+                    }
+                )
+                desired_urls.add(raw_url)
+
+            existing_external_items_by_url: dict[str, list[Any]] = {}
+            managed_external_items: list[tuple[Any, str]] = []
+            existing_subheaders: list[Any] = []
+            if weekly_module is not None:
+                for item in weekly_module.get_module_items():
+                    item_type = str(getattr(item, "type", "")).lower().replace("_", "")
+                    item_title = str(getattr(item, "title", "")).strip()
+                    if item_type == "subheader" and section_header_value:
+                        if item_title == section_header_value:
+                            existing_subheaders.append(item)
+                        continue
+                    if item_type != "externalurl":
+                        continue
+                    external_url = _canonicalize_http_url(
+                        str(getattr(item, "external_url", "")).strip()
+                    )
+                    if external_url:
+                        existing_external_items_by_url.setdefault(external_url, []).append(
+                            item
+                        )
+                        is_managed = False
+                        if normalized_title_prefix and item_title.startswith(
+                            normalized_title_prefix
+                        ):
+                            is_managed = True
+                        if (
+                            normalized_lecture_base
+                            and external_url.startswith(
+                                normalized_lecture_base.rstrip("/") + "/"
+                            )
+                        ):
+                            is_managed = True
+                        if is_managed:
+                            managed_external_items.append((item, external_url))
+
+            if section_header_value:
+                if existing_subheaders:
+                    actions.append(f"slides-header-exists:{weekly_module_name}")
+                    for subheader_item in existing_subheaders:
+                        _ensure_module_item_published(
+                            subheader_item,
+                            item_label=f"{weekly_module_name}:{section_header_value}",
+                        )
+                else:
+                    actions.append(
+                        f"add-slides-header:{weekly_module_name}:{section_header_value}"
+                    )
+                    log.info(
+                        "Adding section header '%s' in module '%s'",
+                        section_header_value,
+                        weekly_module_name,
+                    )
+                    if not dry_run and weekly_module is not None:
+                        created_subheader = weekly_module.create_module_item(
+                            module_item={
+                                "type": "SubHeader",
+                                "title": section_header_value,
+                                "published": True,
+                            }
+                        )
+                        _ensure_module_item_published(
+                            created_subheader,
+                            item_label=f"{weekly_module_name}:{section_header_value}",
+                        )
+
+            if weekly_slides_prune_existing:
+                stale_items = [
+                    (item, url_value)
+                    for item, url_value in managed_external_items
+                    if url_value not in desired_urls
+                ]
+                for stale_item, stale_url in stale_items:
+                    stale_title = str(getattr(stale_item, "title", "")).strip()
+                    actions.append(
+                        f"remove-weekly-link:{weekly_module_name}:{stale_title}:{stale_url}"
+                    )
+                    log.info(
+                        "Removing stale weekly link in '%s': %s (%s)",
+                        weekly_module_name,
+                        stale_title,
+                        stale_url,
+                    )
+                    if not dry_run:
+                        stale_item.delete()
+
+            total_links = len(desired_links)
+            for link_idx, link in enumerate(desired_links, start=1):
+                title = link["title"]
+                url = link["url"]
+                existing_for_url = existing_external_items_by_url.get(url, [])
+                has_matching = False
+                for existing_item in existing_for_url:
+                    existing_title = str(getattr(existing_item, "title", "")).strip()
+                    existing_indent = int(getattr(existing_item, "indent", 0) or 0)
+                    if (
+                        existing_title == title
+                        and existing_indent == normalized_weekly_indent
+                    ):
+                        has_matching = True
+                        break
+
+                if has_matching:
+                    for existing_item in existing_for_url:
+                        existing_title = str(getattr(existing_item, "title", "")).strip()
+                        existing_indent = int(getattr(existing_item, "indent", 0) or 0)
+                        if (
+                            existing_title == title
+                            and existing_indent == normalized_weekly_indent
+                        ):
+                            _ensure_module_item_published(
+                                existing_item,
+                                item_label=f"{weekly_module_name}:{existing_title}",
+                            )
+                            break
+                    if weekly_slides_prune_existing:
+                        for existing_item in existing_for_url:
+                            existing_title = str(
+                                getattr(existing_item, "title", "")
+                            ).strip()
+                            existing_indent = int(
+                                getattr(existing_item, "indent", 0) or 0
+                            )
+                            if (
+                                existing_title == title
+                                and existing_indent == normalized_weekly_indent
+                            ):
+                                continue
+                            actions.append(
+                                f"remove-duplicate-weekly-link:{weekly_module_name}:{existing_title}:{url}"
+                            )
+                            log.info(
+                                "Removing duplicate weekly link in '%s': %s (%s)",
+                                weekly_module_name,
+                                existing_title,
+                                url,
+                            )
+                            if not dry_run:
+                                existing_item.delete()
+                    actions.append(
+                        f"weekly-link-exists:{weekly_module_name}:{title}:{url}"
+                    )
+                    log.info(
+                        "Week %s link %d/%d already present: %s",
+                        weekly_module_name,
+                        link_idx,
+                        total_links,
+                        title,
+                    )
+                    continue
+
+                if weekly_slides_prune_existing:
+                    for existing_item in existing_for_url:
+                        existing_title = str(getattr(existing_item, "title", "")).strip()
+                        actions.append(
+                            f"replace-weekly-link:{weekly_module_name}:{existing_title}:{url}"
+                        )
+                        log.info(
+                            "Replacing weekly link in '%s': %s (%s)",
+                            weekly_module_name,
+                            existing_title,
+                            url,
+                        )
+                        if not dry_run:
+                            existing_item.delete()
+
+                actions.append(f"add-weekly-link:{weekly_module_name}:{title}:{url}")
+                log.info(
+                    "Week %s link %d/%d add: %s",
+                    weekly_module_name,
+                    link_idx,
+                    total_links,
+                    title,
+                )
+                if not dry_run and weekly_module is not None:
+                    created_item = weekly_module.create_module_item(
+                        module_item={
+                            "type": "ExternalUrl",
+                            "title": title,
+                            "external_url": url,
+                            "indent": normalized_weekly_indent,
+                            "new_tab": True,
+                            "published": True,
+                        }
+                    )
+                    _ensure_module_item_published(
+                        created_item,
+                        item_label=f"{weekly_module_name}:{title}",
+                    )
+
+    return {
+        "dry_run": dry_run,
+        "actions": actions,
+        "page_title": page_title,
+        "page_url": page_url,
+        "module_name": module_name,
+        "publish_weekly_slides": publish_weekly_slides,
+        "weekly_module_template": weekly_module_template,
+    }
+
+
+def build_course_calendar(
+    *,
+    plan_path: str | Path,
+    output_dir: str | Path,
+    publish: bool = False,
+    publish_weekly_slides: bool = False,
+    dry_run: bool = True,
+    canvas_course: CanvasCourse | None = None,
+    page_title_override: str | None = None,
+    module_name: str | None = None,
+    weekly_module_template_override: str | None = None,
+) -> CalendarBuildResult:
+    raw = load_course_plan(plan_path)
+    normalized = normalize_course_plan(raw)
+    calendar_json, warnings = build_schedule(normalized)
+    calendar_html = render_calendar_html(normalized, calendar_json)
+
+    output_root = Path(output_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+    html_path = output_root / "calendar.html"
+    json_path = output_root / "calendar.json"
+    normalized_path = output_root / "normalized_plan.yaml"
+
+    yaml = _load_yaml_module()
+    html_path.write_text(calendar_html, encoding="utf-8")
+    json_path.write_text(json.dumps(calendar_json, indent=2) + "\n", encoding="utf-8")
+    normalized_path.write_text(
+        yaml.safe_dump(
+            {
+                **normalized,
+                "term": {
+                    **normalized["term"],
+                    "start_date": normalized["term"]["start_date"].isoformat(),
+                    "end_date": normalized["term"]["end_date"].isoformat(),
+                    "global_no_class_dates": [
+                        d.isoformat()
+                        for d in sorted(normalized["term"]["global_no_class_dates"])
+                    ],
+                    "breaks": [
+                        {
+                            **break_period,
+                            "start_date": break_period["start_date"].isoformat(),
+                            "end_date": break_period["end_date"].isoformat(),
+                            "applies_to": (
+                                sorted(list(break_period["applies_to"]))
+                                if break_period["applies_to"]
+                                else None
+                            ),
+                        }
+                        for break_period in normalized["term"]["breaks"]
+                    ],
+                },
+            },
+            sort_keys=False,
+            allow_unicode=False,
+        ),
+        encoding="utf-8",
+    )
+
+    publish_result = None
+    if publish:
+        if canvas_course is None:
+            raise ValueError("canvas_course is required when publish=True.")
+        page_title = (
+            page_title_override or normalized["publishing"]["schedule_page_title"]
+        )
+        module_name_value = module_name or "Course Schedule"
+        weekly_module_template = (
+            weekly_module_template_override
+            or normalized["publishing"]["module_name_template"]
+        )
+        publish_result = publish_calendar_to_canvas(
+            canvas_course,
+            calendar_json=calendar_json,
+            page_title=page_title,
+            module_name=module_name_value,
+            publish_weekly_slides=publish_weekly_slides,
+            weekly_module_template=weekly_module_template,
+            weekly_slides_title_prefix=normalized["publishing"][
+                "weekly_slides_title_prefix"
+            ],
+            weekly_slides_indent=normalized["publishing"]["weekly_slides_indent"],
+            weekly_slides_section_header=normalized["publishing"][
+                "weekly_slides_section_header"
+            ],
+            weekly_slides_prune_existing=normalized["publishing"][
+                "weekly_slides_prune_existing"
+            ],
+            lecture_slides_base_url=normalized["resource_defaults"][
+                "lecture_slides_base_url"
+            ],
+            html_body=calendar_html,
+            dry_run=dry_run,
+        )
+
+    return CalendarBuildResult(
+        normalized_plan=normalized,
+        calendar_json=calendar_json,
+        calendar_html=calendar_html,
+        warnings=warnings,
+        output_paths={
+            "calendar_html": html_path,
+            "calendar_json": json_path,
+            "normalized_plan": normalized_path,
+        },
+        publish_result=publish_result,
+    )

--- a/lms_interface/helpers.py
+++ b/lms_interface/helpers.py
@@ -3,15 +3,15 @@
 import argparse
 import logging
 from datetime import datetime, timezone
-from typing import Any
-from typing import List
+from pathlib import Path
+from typing import Any, List
 
 import canvasapi
 
 from lms_interface.canvas_interface import (
-  CanvasAssignment,
-  CanvasCourse,
-  CanvasInterface,
+    CanvasAssignment,
+    CanvasCourse,
+    CanvasInterface,
 )
 
 # Configure logging to actually output
@@ -19,183 +19,199 @@ logging.basicConfig()
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
-def delete_empty_folders(canvas_course: CanvasCourse):
-  log.info("delete_empty_folders")
-  num_processed = 0
-  for f in canvas_course.get_folders():
-    try:
-      f.delete()
-      log.info(f"({num_processed}) : \"{f}\" deleted")
-    except canvasapi.exceptions.BadRequest:
-      log.info(f"({num_processed}) : \"{f}\" (not deleted) ({len(list(f.get_files()))})")
-    num_processed += 1
-  
-def get_closed_assignments(interface: CanvasCourse) -> List[canvasapi.assignment.Assignment]:
-  closed_assignments: List[canvasapi.assignment.Assignment] = []
-  for assignment in interface.get_assignments(
-      include=["all_dates"],
-      order_by="name"
-  ):
-    if not assignment.published:
-      continue
-    if assignment.lock_at is not None:
-      # Then it's the easy case because there's no overrides
-      if datetime.fromisoformat(assignment.lock_at) < datetime.now(timezone.utc):
-        # Then the assignment is past due
-        closed_assignments.append(assignment)
-        continue
-    elif assignment.all_dates is not None:
-      
-      # First we need to figure out what the latest time this assignment could be available is
-      # todo: This could be done on a per-student basis
-      last_lock_datetime = None
-      for dates_dict in assignment.all_dates:
-        if dates_dict["lock_at"] is not None:
-          lock_datetime = datetime.fromisoformat(dates_dict["lock_at"])
-          if (last_lock_datetime is None) or (lock_datetime >= last_lock_datetime):
-            last_lock_datetime = lock_datetime
-      
-      # If we have found a valid lock time, and it's in the past then we lock
-      if last_lock_datetime is not None and last_lock_datetime <= datetime.now(timezone.utc):
-        closed_assignments.append(assignment)
-        continue
-    
-    else:
-      log.warning(f"Cannot find any lock dates for assignment {assignment.name}!")
-  
-  return closed_assignments
 
-def get_unsubmitted_submissions(interface: CanvasCourse, assignment: canvasapi.assignment.Assignment) -> List[
-  canvasapi.submission.Submission]:
-  submissions: List[canvasapi.submission.Submission] = list(
-    filter(
-      lambda s: s.submitted_at is None and s.percentage_score is None and not s.excused,
-      assignment.get_submissions()
+def delete_empty_folders(canvas_course: CanvasCourse):
+    log.info("delete_empty_folders")
+    num_processed = 0
+    for f in canvas_course.get_folders():
+        try:
+            f.delete()
+            log.info(f'({num_processed}) : "{f}" deleted')
+        except canvasapi.exceptions.BadRequest:
+            log.info(
+                f'({num_processed}) : "{f}" (not deleted) ({len(list(f.get_files()))})'
+            )
+        num_processed += 1
+
+
+def get_closed_assignments(
+    interface: CanvasCourse,
+) -> List[canvasapi.assignment.Assignment]:
+    closed_assignments: List[canvasapi.assignment.Assignment] = []
+    for assignment in interface.get_assignments(include=["all_dates"], order_by="name"):
+        if not assignment.published:
+            continue
+        if assignment.lock_at is not None:
+            # Then it's the easy case because there's no overrides
+            if datetime.fromisoformat(assignment.lock_at) < datetime.now(timezone.utc):
+                # Then the assignment is past due
+                closed_assignments.append(assignment)
+                continue
+        elif assignment.all_dates is not None:
+
+            # First we need to figure out what the latest time this assignment could be available is
+            # todo: This could be done on a per-student basis
+            last_lock_datetime = None
+            for dates_dict in assignment.all_dates:
+                if dates_dict["lock_at"] is not None:
+                    lock_datetime = datetime.fromisoformat(dates_dict["lock_at"])
+                    if (last_lock_datetime is None) or (
+                        lock_datetime >= last_lock_datetime
+                    ):
+                        last_lock_datetime = lock_datetime
+
+            # If we have found a valid lock time, and it's in the past then we lock
+            if last_lock_datetime is not None and last_lock_datetime <= datetime.now(
+                timezone.utc
+            ):
+                closed_assignments.append(assignment)
+                continue
+
+        else:
+            log.warning(f"Cannot find any lock dates for assignment {assignment.name}!")
+
+    return closed_assignments
+
+
+def get_unsubmitted_submissions(
+    interface: CanvasCourse, assignment: canvasapi.assignment.Assignment
+) -> List[canvasapi.submission.Submission]:
+    submissions: List[canvasapi.submission.Submission] = list(
+        filter(
+            lambda s: s.submitted_at is None
+            and s.percentage_score is None
+            and not s.excused,
+            assignment.get_submissions(),
+        )
     )
-  )
-  return submissions
+    return submissions
+
 
 def clear_out_missing(interface: CanvasCourse):
-  assignments = get_closed_assignments(interface)
-  for assignment in assignments:
-    missing_submissions = get_unsubmitted_submissions(interface, assignment)
-    if not missing_submissions:
-      continue
-    log.info(
-      f"Assignment: ({assignment.quiz_id if hasattr(assignment, 'quiz_id') else assignment.id}) {assignment.name} {assignment.published}"
-    )
-    for submission in missing_submissions:
-      log.info(
-        f"{submission.user_id} ({interface.get_username(submission.user_id)}) : {submission.workflow_state} : {submission.missing} : {submission.score} : {submission.grader_id} : {submission.graded_at}"
-      )
-      submission.edit(submission={"late_policy_status": "missing"})
-    log.info("")
+    assignments = get_closed_assignments(interface)
+    for assignment in assignments:
+        missing_submissions = get_unsubmitted_submissions(interface, assignment)
+        if not missing_submissions:
+            continue
+        log.info(
+            f"Assignment: ({assignment.quiz_id if hasattr(assignment, 'quiz_id') else assignment.id}) {assignment.name} {assignment.published}"
+        )
+        for submission in missing_submissions:
+            log.info(
+                f"{submission.user_id} ({interface.get_username(submission.user_id)}) : {submission.workflow_state} : {submission.missing} : {submission.score} : {submission.grader_id} : {submission.graded_at}"
+            )
+            submission.edit(submission={"late_policy_status": "missing"})
+        log.info("")
 
 
 def _parse_canvas_datetime(value: Any) -> datetime | None:
-  if value is None:
-    return None
-  if not isinstance(value, str):
-    return None
-  normalized = value.strip()
-  if not normalized:
-    return None
-  if normalized.endswith("Z"):
-    normalized = normalized[:-1] + "+00:00"
-  try:
-    dt = datetime.fromisoformat(normalized)
-  except ValueError:
-    return None
-  if dt.tzinfo is None:
-    dt = dt.replace(tzinfo=timezone.utc)
-  return dt.astimezone(timezone.utc)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
 
 
 def _resolve_submission_due_at(
     assignment: canvasapi.assignment.Assignment,
-    submission: canvasapi.submission.Submission
+    submission: canvasapi.submission.Submission,
 ) -> datetime | None:
-  # Most specific: submission-specific cached due date from Canvas.
-  for value in (
-      getattr(submission, "cached_due_date", None),
-      getattr(submission, "due_at", None),
-  ):
-    parsed = _parse_canvas_datetime(value)
-    if parsed is not None:
-      return parsed
+    # Most specific: submission-specific cached due date from Canvas.
+    for value in (
+        getattr(submission, "cached_due_date", None),
+        getattr(submission, "due_at", None),
+    ):
+        parsed = _parse_canvas_datetime(value)
+        if parsed is not None:
+            return parsed
 
-  # Sometimes the submission includes nested assignment metadata.
-  submission_assignment = getattr(submission, "assignment", None)
-  if isinstance(submission_assignment, dict):
-    parsed = _parse_canvas_datetime(submission_assignment.get("due_at"))
-    if parsed is not None:
-      return parsed
-  elif submission_assignment is not None:
-    parsed = _parse_canvas_datetime(getattr(submission_assignment, "due_at", None))
-    if parsed is not None:
-      return parsed
+    # Sometimes the submission includes nested assignment metadata.
+    submission_assignment = getattr(submission, "assignment", None)
+    if isinstance(submission_assignment, dict):
+        parsed = _parse_canvas_datetime(submission_assignment.get("due_at"))
+        if parsed is not None:
+            return parsed
+    elif submission_assignment is not None:
+        parsed = _parse_canvas_datetime(getattr(submission_assignment, "due_at", None))
+        if parsed is not None:
+            return parsed
 
-  # Fallback to assignment-level due date.
-  return _parse_canvas_datetime(getattr(assignment, "due_at", None))
+    # Fallback to assignment-level due date.
+    return _parse_canvas_datetime(getattr(assignment, "due_at", None))
 
 
-def _submission_content_signals(submission: canvasapi.submission.Submission) -> list[str]:
-  signals: list[str] = []
+def _submission_content_signals(
+    submission: canvasapi.submission.Submission,
+) -> list[str]:
+    signals: list[str] = []
 
-  submission_type = str(getattr(submission, "submission_type", "") or "").strip().lower()
-  if submission_type and submission_type not in {"none", "on_paper", "not_graded"}:
-    signals.append(f"submission_type={submission_type}")
+    submission_type = (
+        str(getattr(submission, "submission_type", "") or "").strip().lower()
+    )
+    if submission_type and submission_type not in {"none", "on_paper", "not_graded"}:
+        signals.append(f"submission_type={submission_type}")
 
-  attachments = getattr(submission, "attachments", None)
-  if isinstance(attachments, list) and len(attachments) > 0:
-    signals.append(f"attachments={len(attachments)}")
+    attachments = getattr(submission, "attachments", None)
+    if isinstance(attachments, list) and len(attachments) > 0:
+        signals.append(f"attachments={len(attachments)}")
 
-  body = getattr(submission, "body", None)
-  if isinstance(body, str) and body.strip():
-    signals.append("body")
+    body = getattr(submission, "body", None)
+    if isinstance(body, str) and body.strip():
+        signals.append("body")
 
-  url = getattr(submission, "url", None)
-  if isinstance(url, str) and url.strip():
-    signals.append("url")
+    url = getattr(submission, "url", None)
+    if isinstance(url, str) and url.strip():
+        signals.append("url")
 
-  media_comment_id = getattr(submission, "media_comment_id", None)
-  if media_comment_id not in (None, "", 0):
-    signals.append("media_comment")
+    media_comment_id = getattr(submission, "media_comment_id", None)
+    if media_comment_id not in (None, "", 0):
+        signals.append("media_comment")
 
-  return signals
+    return signals
 
 
 def _normalize_late_policy_status(value: Any) -> str:
-  if value is None:
-    return "none"
-  return str(value).strip().lower()
+    if value is None:
+        return "none"
+    return str(value).strip().lower()
 
 
 def _normalize_grade(value: Any) -> str:
-  if value is None:
-    return ""
-  return str(value).strip().lower()
+    if value is None:
+        return ""
+    return str(value).strip().lower()
 
 
 def _placeholder_grade_needs_clear(submission: canvasapi.submission.Submission) -> bool:
-  grade = _normalize_grade(getattr(submission, "grade", None))
-  posted_grade = _normalize_grade(getattr(submission, "posted_grade", None))
-  entered_grade = _normalize_grade(getattr(submission, "entered_grade", None))
-  score = getattr(submission, "score", None)
+    grade = _normalize_grade(getattr(submission, "grade", None))
+    posted_grade = _normalize_grade(getattr(submission, "posted_grade", None))
+    entered_grade = _normalize_grade(getattr(submission, "entered_grade", None))
+    score = getattr(submission, "score", None)
 
-  grade_tokens = {grade, posted_grade, entered_grade}
-  if any(token in {"incomplete", "fail", "f"} for token in grade_tokens):
-    return True
-  if any(token in {"0", "0.0", "0.00"} for token in grade_tokens):
-    return True
+    grade_tokens = {grade, posted_grade, entered_grade}
+    if any(token in {"incomplete", "fail", "f"} for token in grade_tokens):
+        return True
+    if any(token in {"0", "0.0", "0.00"} for token in grade_tokens):
+        return True
 
-  try:
-    if score is not None and float(score) == 0.0:
-      return True
-  except Exception:
-    pass
+    try:
+        if score is not None and float(score) == 0.0:
+            return True
+    except Exception:
+        pass
 
-  return False
+    return False
 
 
 def cleanup_missing_by_due_date(
@@ -207,397 +223,479 @@ def cleanup_missing_by_due_date(
     limit: int | None = None,
     force_clear_stale_missing: bool = True,
     clear_placeholder_grade: bool = False,
-    now: datetime | None = None
+    now: datetime | None = None,
 ) -> dict[str, int]:
-  """
-  Normalize late policy status for *unsubmitted* work:
-    - Due date passed  -> `missing`
-    - Due date future  -> `none`
+    """
+    Normalize late policy status for *unsubmitted* work:
+      - Due date passed  -> `missing`
+      - Due date future  -> `none`
 
-  Uses Assignment.get_submission(user_id) for each student/assignment pair.
-  """
-  if now is None:
-    now = datetime.now(timezone.utc)
-  elif now.tzinfo is None:
-    now = now.replace(tzinfo=timezone.utc)
-  else:
-    now = now.astimezone(timezone.utc)
+    Uses Assignment.get_submission(user_id) for each student/assignment pair.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = now.astimezone(timezone.utc)
 
-  stats = {
-    "assignments_considered": 0,
-    "students_available": 0,
-    "student_limit": limit if limit is not None else 0,
-    "students_considered": 0,
-    "submissions_checked": 0,
-    "unsubmitted_considered": 0,
-    "desired_missing": 0,
-    "desired_none": 0,
-    "current_missing": 0,
-    "current_none": 0,
-    "current_other": 0,
-    "missing_flag_true": 0,
-    "missing_flag_false": 0,
-    "submitted_with_content": 0,
-    "placeholder_without_content": 0,
-    "placeholder_grade_needs_clear": 0,
-    "placeholder_grade_clear_attempted": 0,
-    "placeholder_grade_clear_succeeded": 0,
-    "placeholder_grade_clear_failed": 0,
-    "updated_to_missing": 0,
-    "updated_to_none": 0,
-    "forced_none_due_stale_missing_flag": 0,
-    "unchanged": 0,
-    "unchanged_missing": 0,
-    "unchanged_none": 0,
-    "unchanged_other": 0,
-    "skipped_excused": 0,
-    "skipped_submitted": 0,
-    "skipped_no_due_date": 0,
-    "errors": 0,
-  }
-
-  students = list(canvas_course.get_students(include_names=False))
-  stats["students_available"] = len(students)
-  if limit is not None:
-    students = students[:limit]
-  assignments = list(canvas_course.get_assignments(include=["all_dates"], order_by="name"))
-
-  total_assignments = len(assignments)
-  for assignment_index, assignment in enumerate(assignments, start=1):
-    if assignment_id is not None and assignment.id != assignment_id:
-      continue
-    if not include_unpublished and not getattr(assignment, "published", True):
-      continue
-    stats["assignments_considered"] += 1
-    assignment_updates_to_missing = 0
-    assignment_updates_to_none = 0
-    assignment_unchanged = 0
-    assignment_skipped_excused = 0
-    assignment_skipped_submitted = 0
-    assignment_skipped_no_due_date = 0
-    assignment_errors = 0
-    assignment_unsubmitted = 0
-
-    assignment_name = getattr(assignment, "name", f"assignment_{assignment.id}")
-    log.info(
-      f"[{assignment_index}/{total_assignments}] Checking assignment "
-      f"{assignment.id} ({assignment_name})"
-    )
-
-    for student in students:
-      user_id = student.user_id
-      stats["students_considered"] += 1
-      try:
-        submission = assignment.get_submission(user_id)
-      except Exception as e:
-        stats["errors"] += 1
-        assignment_errors += 1
-        log.warning(
-          f"Skipping assignment={assignment.id} user={user_id}: could not fetch submission ({e})"
-        )
-        continue
-
-      stats["submissions_checked"] += 1
-
-      if bool(getattr(submission, "excused", False)):
-        stats["skipped_excused"] += 1
-        assignment_skipped_excused += 1
-        continue
-
-      content_signals = _submission_content_signals(submission)
-      if content_signals:
-        stats["skipped_submitted"] += 1
-        stats["submitted_with_content"] += 1
-        assignment_skipped_submitted += 1
-        continue
-
-      workflow_state = str(getattr(submission, "workflow_state", "") or "").strip().lower()
-      submitted_at = getattr(submission, "submitted_at", None)
-      if workflow_state in {"submitted", "graded", "pending_review"} or submitted_at is not None:
-        stats["placeholder_without_content"] += 1
-        log.debug(
-          f"Treating placeholder as unsubmitted for assignment={assignment.id} user={user_id}: "
-          f"workflow_state={workflow_state!r}, submitted_at={submitted_at!r}, "
-          f"submission_type={getattr(submission, 'submission_type', None)!r}"
-        )
-
-      stats["unsubmitted_considered"] += 1
-      assignment_unsubmitted += 1
-
-      due_at = _resolve_submission_due_at(assignment, submission)
-      if due_at is None:
-        stats["skipped_no_due_date"] += 1
-        assignment_skipped_no_due_date += 1
-        continue
-
-      desired_status = "missing" if due_at <= now else "none"
-      if desired_status == "missing":
-        stats["desired_missing"] += 1
-      else:
-        stats["desired_none"] += 1
-
-      current_status = _normalize_late_policy_status(
-        getattr(submission, "late_policy_status", None))
-      missing_flag = bool(getattr(submission, "missing", False))
-      if missing_flag:
-        stats["missing_flag_true"] += 1
-      else:
-        stats["missing_flag_false"] += 1
-      if current_status == "missing":
-        stats["current_missing"] += 1
-      elif current_status == "none":
-        stats["current_none"] += 1
-      else:
-        stats["current_other"] += 1
-
-      # Canvas can report stale `missing=True` even when late_policy_status is already
-      # `none`; writing `none` again is a cheap nudge to recompute server-side state.
-      if (force_clear_stale_missing and desired_status == "none"
-          and current_status == "none" and missing_flag):
-        log.debug(
-          f"assignment={assignment.id} user={user_id} "
-          f"forcing late_policy_status none (stale missing flag true)"
-        )
-        if not dry_run:
-          submission.edit(submission={"late_policy_status": "none"})
-        stats["updated_to_none"] += 1
-        stats["forced_none_due_stale_missing_flag"] += 1
-        assignment_updates_to_none += 1
-        continue
-
-      if (clear_placeholder_grade and desired_status == "none"
-          and _placeholder_grade_needs_clear(submission)):
-        stats["placeholder_grade_needs_clear"] += 1
-        stats["placeholder_grade_clear_attempted"] += 1
-        log.debug(
-          f"assignment={assignment.id} user={user_id} "
-          f"clearing placeholder grade "
-          f"(grade={getattr(submission, 'grade', None)!r}, "
-          f"posted_grade={getattr(submission, 'posted_grade', None)!r}, "
-          f"entered_grade={getattr(submission, 'entered_grade', None)!r}, "
-          f"score={getattr(submission, 'score', None)!r})"
-        )
-        if not dry_run:
-          cleared = False
-          for payload in ("", None):
-            try:
-              submission.edit(submission={"posted_grade": payload, "late_policy_status": "none"})
-              cleared = True
-              break
-            except Exception as e:
-              log.warning(
-                f"assignment={assignment.id} user={user_id} "
-                f"failed clearing placeholder grade with payload={payload!r}: {e}"
-              )
-          if cleared:
-            stats["placeholder_grade_clear_succeeded"] += 1
-          else:
-            stats["placeholder_grade_clear_failed"] += 1
-            stats["errors"] += 1
-        else:
-          stats["placeholder_grade_clear_succeeded"] += 1
-        continue
-
-      if current_status == desired_status:
-        stats["unchanged"] += 1
-        assignment_unchanged += 1
-        if current_status == "missing":
-          stats["unchanged_missing"] += 1
-        elif current_status == "none":
-          stats["unchanged_none"] += 1
-        else:
-          stats["unchanged_other"] += 1
-        continue
-
-      log.debug(
-        f"assignment={assignment.id} user={user_id} "
-        f"due_at={due_at.isoformat()} now={now.isoformat()} "
-        f"late_policy_status: {current_status} -> {desired_status}"
-      )
-      if not dry_run:
-        submission.edit(submission={"late_policy_status": desired_status})
-
-      if desired_status == "missing":
-        stats["updated_to_missing"] += 1
-        assignment_updates_to_missing += 1
-      else:
-        stats["updated_to_none"] += 1
-        assignment_updates_to_none += 1
-
-    log.info(
-      f"[{assignment_index}/{total_assignments}] assignment={assignment.id} summary: "
-      f"unsubmitted={assignment_unsubmitted}, "
-      f"updated_to_missing={assignment_updates_to_missing}, "
-      f"updated_to_none={assignment_updates_to_none}, "
-      f"unchanged={assignment_unchanged}, "
-      f"skipped_excused={assignment_skipped_excused}, "
-      f"skipped_submitted={assignment_skipped_submitted}, "
-      f"skipped_no_due_date={assignment_skipped_no_due_date}, "
-      f"errors={assignment_errors}"
-    )
-
-  return stats
-
-def deprecate_assignment(canvas_course: CanvasCourse, assignment_id) -> List[canvasapi.assignment.Assignment]:
-  
-  log.debug(canvas_course.__dict__)
-  
-  # for assignment in canvas_course.get_assignments():
-  #   print(assignment)
-  
-  canvas_assignment: CanvasAssignment = canvas_course.get_assignment(assignment_id=assignment_id)
-  
-  canvas_assignment.assignment.edit(
-    assignment={
-      "name": f"{canvas_assignment.assignment.name} (deprecated)",
-      "due_at": f"{datetime.now(timezone.utc).isoformat()}",
-      "lock_at": f"{datetime.now(timezone.utc).isoformat()}"
+    stats = {
+        "assignments_considered": 0,
+        "students_available": 0,
+        "student_limit": limit if limit is not None else 0,
+        "students_considered": 0,
+        "submissions_checked": 0,
+        "unsubmitted_considered": 0,
+        "desired_missing": 0,
+        "desired_none": 0,
+        "current_missing": 0,
+        "current_none": 0,
+        "current_other": 0,
+        "missing_flag_true": 0,
+        "missing_flag_false": 0,
+        "submitted_with_content": 0,
+        "placeholder_without_content": 0,
+        "placeholder_grade_needs_clear": 0,
+        "placeholder_grade_clear_attempted": 0,
+        "placeholder_grade_clear_succeeded": 0,
+        "placeholder_grade_clear_failed": 0,
+        "updated_to_missing": 0,
+        "updated_to_none": 0,
+        "forced_none_due_stale_missing_flag": 0,
+        "unchanged": 0,
+        "unchanged_missing": 0,
+        "unchanged_none": 0,
+        "unchanged_other": 0,
+        "skipped_excused": 0,
+        "skipped_submitted": 0,
+        "skipped_no_due_date": 0,
+        "errors": 0,
     }
-  )
+
+    students = list(canvas_course.get_students(include_names=False))
+    stats["students_available"] = len(students)
+    if limit is not None:
+        students = students[:limit]
+    assignments = list(
+        canvas_course.get_assignments(include=["all_dates"], order_by="name")
+    )
+
+    total_assignments = len(assignments)
+    for assignment_index, assignment in enumerate(assignments, start=1):
+        if assignment_id is not None and assignment.id != assignment_id:
+            continue
+        if not include_unpublished and not getattr(assignment, "published", True):
+            continue
+        stats["assignments_considered"] += 1
+        assignment_updates_to_missing = 0
+        assignment_updates_to_none = 0
+        assignment_unchanged = 0
+        assignment_skipped_excused = 0
+        assignment_skipped_submitted = 0
+        assignment_skipped_no_due_date = 0
+        assignment_errors = 0
+        assignment_unsubmitted = 0
+
+        assignment_name = getattr(assignment, "name", f"assignment_{assignment.id}")
+        log.info(
+            f"[{assignment_index}/{total_assignments}] Checking assignment "
+            f"{assignment.id} ({assignment_name})"
+        )
+
+        for student in students:
+            user_id = student.user_id
+            stats["students_considered"] += 1
+            try:
+                submission = assignment.get_submission(user_id)
+            except Exception as e:
+                stats["errors"] += 1
+                assignment_errors += 1
+                log.warning(
+                    f"Skipping assignment={assignment.id} user={user_id}: could not fetch submission ({e})"
+                )
+                continue
+
+            stats["submissions_checked"] += 1
+
+            if bool(getattr(submission, "excused", False)):
+                stats["skipped_excused"] += 1
+                assignment_skipped_excused += 1
+                continue
+
+            content_signals = _submission_content_signals(submission)
+            if content_signals:
+                stats["skipped_submitted"] += 1
+                stats["submitted_with_content"] += 1
+                assignment_skipped_submitted += 1
+                continue
+
+            workflow_state = (
+                str(getattr(submission, "workflow_state", "") or "").strip().lower()
+            )
+            submitted_at = getattr(submission, "submitted_at", None)
+            if (
+                workflow_state in {"submitted", "graded", "pending_review"}
+                or submitted_at is not None
+            ):
+                stats["placeholder_without_content"] += 1
+                log.debug(
+                    f"Treating placeholder as unsubmitted for assignment={assignment.id} user={user_id}: "
+                    f"workflow_state={workflow_state!r}, submitted_at={submitted_at!r}, "
+                    f"submission_type={getattr(submission, 'submission_type', None)!r}"
+                )
+
+            stats["unsubmitted_considered"] += 1
+            assignment_unsubmitted += 1
+
+            due_at = _resolve_submission_due_at(assignment, submission)
+            if due_at is None:
+                stats["skipped_no_due_date"] += 1
+                assignment_skipped_no_due_date += 1
+                continue
+
+            desired_status = "missing" if due_at <= now else "none"
+            if desired_status == "missing":
+                stats["desired_missing"] += 1
+            else:
+                stats["desired_none"] += 1
+
+            current_status = _normalize_late_policy_status(
+                getattr(submission, "late_policy_status", None)
+            )
+            missing_flag = bool(getattr(submission, "missing", False))
+            if missing_flag:
+                stats["missing_flag_true"] += 1
+            else:
+                stats["missing_flag_false"] += 1
+            if current_status == "missing":
+                stats["current_missing"] += 1
+            elif current_status == "none":
+                stats["current_none"] += 1
+            else:
+                stats["current_other"] += 1
+
+            # Canvas can report stale `missing=True` even when late_policy_status is already
+            # `none`; writing `none` again is a cheap nudge to recompute server-side state.
+            if (
+                force_clear_stale_missing
+                and desired_status == "none"
+                and current_status == "none"
+                and missing_flag
+            ):
+                log.debug(
+                    f"assignment={assignment.id} user={user_id} "
+                    f"forcing late_policy_status none (stale missing flag true)"
+                )
+                if not dry_run:
+                    submission.edit(submission={"late_policy_status": "none"})
+                stats["updated_to_none"] += 1
+                stats["forced_none_due_stale_missing_flag"] += 1
+                assignment_updates_to_none += 1
+                continue
+
+            if (
+                clear_placeholder_grade
+                and desired_status == "none"
+                and _placeholder_grade_needs_clear(submission)
+            ):
+                stats["placeholder_grade_needs_clear"] += 1
+                stats["placeholder_grade_clear_attempted"] += 1
+                log.debug(
+                    f"assignment={assignment.id} user={user_id} "
+                    f"clearing placeholder grade "
+                    f"(grade={getattr(submission, 'grade', None)!r}, "
+                    f"posted_grade={getattr(submission, 'posted_grade', None)!r}, "
+                    f"entered_grade={getattr(submission, 'entered_grade', None)!r}, "
+                    f"score={getattr(submission, 'score', None)!r})"
+                )
+                if not dry_run:
+                    cleared = False
+                    for payload in ("", None):
+                        try:
+                            submission.edit(
+                                submission={
+                                    "posted_grade": payload,
+                                    "late_policy_status": "none",
+                                }
+                            )
+                            cleared = True
+                            break
+                        except Exception as e:
+                            log.warning(
+                                f"assignment={assignment.id} user={user_id} "
+                                f"failed clearing placeholder grade with payload={payload!r}: {e}"
+                            )
+                    if cleared:
+                        stats["placeholder_grade_clear_succeeded"] += 1
+                    else:
+                        stats["placeholder_grade_clear_failed"] += 1
+                        stats["errors"] += 1
+                else:
+                    stats["placeholder_grade_clear_succeeded"] += 1
+                continue
+
+            if current_status == desired_status:
+                stats["unchanged"] += 1
+                assignment_unchanged += 1
+                if current_status == "missing":
+                    stats["unchanged_missing"] += 1
+                elif current_status == "none":
+                    stats["unchanged_none"] += 1
+                else:
+                    stats["unchanged_other"] += 1
+                continue
+
+            log.debug(
+                f"assignment={assignment.id} user={user_id} "
+                f"due_at={due_at.isoformat()} now={now.isoformat()} "
+                f"late_policy_status: {current_status} -> {desired_status}"
+            )
+            if not dry_run:
+                submission.edit(submission={"late_policy_status": desired_status})
+
+            if desired_status == "missing":
+                stats["updated_to_missing"] += 1
+                assignment_updates_to_missing += 1
+            else:
+                stats["updated_to_none"] += 1
+                assignment_updates_to_none += 1
+
+        log.info(
+            f"[{assignment_index}/{total_assignments}] assignment={assignment.id} summary: "
+            f"unsubmitted={assignment_unsubmitted}, "
+            f"updated_to_missing={assignment_updates_to_missing}, "
+            f"updated_to_none={assignment_updates_to_none}, "
+            f"unchanged={assignment_unchanged}, "
+            f"skipped_excused={assignment_skipped_excused}, "
+            f"skipped_submitted={assignment_skipped_submitted}, "
+            f"skipped_no_due_date={assignment_skipped_no_due_date}, "
+            f"errors={assignment_errors}"
+        )
+
+    return stats
+
+
+def deprecate_assignment(
+    canvas_course: CanvasCourse, assignment_id
+) -> List[canvasapi.assignment.Assignment]:
+
+    log.debug(canvas_course.__dict__)
+
+    # for assignment in canvas_course.get_assignments():
+    #   print(assignment)
+
+    canvas_assignment: CanvasAssignment = canvas_course.get_assignment(
+        assignment_id=assignment_id
+    )
+
+    canvas_assignment.assignment.edit(
+        assignment={
+            "name": f"{canvas_assignment.assignment.name} (deprecated)",
+            "due_at": f"{datetime.now(timezone.utc).isoformat()}",
+            "lock_at": f"{datetime.now(timezone.utc).isoformat()}",
+        }
+    )
+
 
 def mark_future_assignments_as_ungraded(canvas_course: CanvasCourse):
-  
-  for assignment in canvas_course.get_assignments(
-      include=["all_dates"],
-      order_by="name"
-  ):
-    if assignment.unlock_at is not None:
-      if datetime.fromisoformat(assignment.unlock_at) > datetime.now(timezone.utc):
-        log.debug(assignment)
-        for submission in assignment.get_submissions():
-          submission.mark_unread()
+
+    for assignment in canvas_course.get_assignments(
+        include=["all_dates"], order_by="name"
+    ):
+        if assignment.unlock_at is not None:
+            if datetime.fromisoformat(assignment.unlock_at) > datetime.now(
+                timezone.utc
+            ):
+                log.debug(assignment)
+                for submission in assignment.get_submissions():
+                    submission.mark_unread()
 
 
 def main():
 
-  # Mapping of short CLI names to helper functions
-  HELPERS = {
-    "clean-folders": ("delete_empty_folders", False),
-    "closed": ("get_closed_assignments", False),
-    "unsubmitted": ("get_unsubmitted_submissions", True),
-    "missing": ("clear_out_missing", False),
-    "cleanup-missing": ("cleanup_missing_by_due_date", False),
-    "deprecate": ("deprecate_assignment", True),
-    "ungraded": ("mark_future_assignments_as_ungraded", False),
-  }
+    # Mapping of short CLI names to helper functions
+    HELPERS = {
+        "clean-folders": ("delete_empty_folders", False),
+        "closed": ("get_closed_assignments", False),
+        "unsubmitted": ("get_unsubmitted_submissions", True),
+        "missing": ("clear_out_missing", False),
+        "cleanup-missing": ("cleanup_missing_by_due_date", False),
+        "deprecate": ("deprecate_assignment", True),
+        "ungraded": ("mark_future_assignments_as_ungraded", False),
+        "plan-course": ("plan_course", False),
+    }
 
-  parser = argparse.ArgumentParser(
-    description="Canvas helper utilities for common course management tasks"
-  )
-
-  parser.add_argument(
-    "helper",
-    choices=HELPERS.keys(),
-    help="Helper function to run"
-  )
-
-  parser.add_argument(
-    "--course-id",
-    type=int,
-    required=True,
-    help="Canvas course ID"
-  )
-
-  parser.add_argument(
-    "--assignment-id",
-    type=int,
-    help="Canvas assignment ID (required for deprecate/unsubmitted, optional for cleanup-missing)"
-  )
-  parser.add_argument(
-    "--limit",
-    type=int,
-    help="Limit processing to first N students (optional, cleanup-missing only)"
-  )
-
-  parser.add_argument(
-    "--prod",
-    action="store_true",
-    help="Use production Canvas instance instead of development"
-  )
-  parser.add_argument(
-    "--dry-run",
-    action="store_true",
-    help="Report updates without writing changes to Canvas"
-  )
-  parser.add_argument(
-    "--include-unpublished",
-    action="store_true",
-    help="Also process unpublished assignments"
-  )
-  parser.add_argument(
-    "--debug",
-    action="store_true",
-    help="Enable verbose per-student debug logging"
-  )
-  parser.add_argument(
-    "--no-force-clear-stale-missing",
-    action="store_true",
-    help="Do not force-write late_policy_status=none when Canvas reports missing=True with future due date"
-  )
-  parser.add_argument(
-    "--clear-placeholder-grade",
-    action="store_true",
-    help="Attempt to clear stale placeholder grades (e.g., Incomplete/0) on future-due, no-content submissions"
-  )
-
-  args = parser.parse_args()
-  if args.debug:
-    log.setLevel(logging.DEBUG)
-
-  # Get helper function name and whether it requires assignment_id
-  helper_func_name, requires_assignment = HELPERS[args.helper]
-
-  # Validate assignment_id requirement
-  if requires_assignment and not args.assignment_id:
-    parser.error(f"--assignment-id is required for '{args.helper}'")
-  if args.limit is not None and args.limit < 1:
-    parser.error("--limit must be >= 1")
-
-  # Initialize Canvas interface and course
-  canvas_interface = CanvasInterface(prod=args.prod)
-  canvas_course = canvas_interface.get_course(args.course_id)
-
-  # Run the requested helper
-  if helper_func_name == "delete_empty_folders":
-    delete_empty_folders(canvas_course)
-
-  elif helper_func_name == "get_closed_assignments":
-    assignments = get_closed_assignments(canvas_course)
-    log.info(f"Found {len(assignments)} closed assignments:")
-    for assignment in assignments:
-      log.info(f"  - {assignment.name} (ID: {assignment.id})")
-
-  elif helper_func_name == "get_unsubmitted_submissions":
-    assignment = canvas_course.get_assignment(args.assignment_id)
-    submissions = get_unsubmitted_submissions(canvas_course, assignment.assignment)
-    log.info(f"Found {len(submissions)} unsubmitted submissions:")
-    for submission in submissions:
-      log.info(f"  - User {submission.user_id}")
-
-  elif helper_func_name == "clear_out_missing":
-    clear_out_missing(canvas_course)
-
-  elif helper_func_name == "cleanup_missing_by_due_date":
-    stats = cleanup_missing_by_due_date(
-      canvas_course,
-      dry_run=args.dry_run,
-      include_unpublished=args.include_unpublished,
-      assignment_id=args.assignment_id,
-      limit=args.limit,
-      force_clear_stale_missing=not args.no_force_clear_stale_missing,
-      clear_placeholder_grade=args.clear_placeholder_grade
+    parser = argparse.ArgumentParser(
+        description="Canvas helper utilities for common course management tasks"
     )
-    log.info(f"cleanup-missing summary (dry_run={args.dry_run}):")
-    for key, value in stats.items():
-      log.info(f"  {key}: {value}")
 
-  elif helper_func_name == "deprecate_assignment":
-    deprecate_assignment(canvas_course, args.assignment_id)
-    log.info(f"Assignment {args.assignment_id} has been deprecated")
+    parser.add_argument("helper", choices=HELPERS.keys(), help="Helper function to run")
 
-  elif helper_func_name == "mark_future_assignments_as_ungraded":
-    mark_future_assignments_as_ungraded(canvas_course)
+    parser.add_argument("--course-id", type=int, help="Canvas course ID")
+
+    parser.add_argument(
+        "--assignment-id",
+        type=int,
+        help="Canvas assignment ID (required for deprecate/unsubmitted, optional for cleanup-missing)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Limit processing to first N students (optional, cleanup-missing only)",
+    )
+
+    parser.add_argument(
+        "--prod",
+        action="store_true",
+        help="Use production Canvas instance instead of development",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report updates without writing changes to Canvas",
+    )
+    parser.add_argument(
+        "--include-unpublished",
+        action="store_true",
+        help="Also process unpublished assignments",
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Enable verbose per-student debug logging"
+    )
+    parser.add_argument(
+        "--no-force-clear-stale-missing",
+        action="store_true",
+        help="Do not force-write late_policy_status=none when Canvas reports missing=True with future due date",
+    )
+    parser.add_argument(
+        "--clear-placeholder-grade",
+        action="store_true",
+        help="Attempt to clear stale placeholder grades (e.g., Incomplete/0) on future-due, no-content submissions",
+    )
+    parser.add_argument(
+        "--yaml-path", help="Path to course plan YAML file (required for plan-course)"
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="build/course_plan",
+        help="Directory for generated calendar outputs (plan-course)",
+    )
+    parser.add_argument(
+        "--publish",
+        action="store_true",
+        help="Publish generated schedule page to Canvas (plan-course)",
+    )
+    parser.add_argument(
+        "--page-title",
+        help="Override Canvas schedule page title when publishing (plan-course)",
+    )
+    parser.add_argument(
+        "--module-name",
+        default="Course Schedule",
+        help="Canvas module name for schedule page link when publishing (plan-course)",
+    )
+    parser.add_argument(
+        "--publish-weekly-slides",
+        action="store_true",
+        help="Create/reuse Week modules and publish weekly slide URL links (plan-course)",
+    )
+    parser.add_argument(
+        "--weekly-module-template",
+        help="Template for weekly module names, e.g. 'Week {week_number}' (plan-course)",
+    )
+
+    args = parser.parse_args()
+    if args.debug:
+        log.setLevel(logging.DEBUG)
+
+    # Get helper function name and whether it requires assignment_id
+    helper_func_name, requires_assignment = HELPERS[args.helper]
+
+    # Validate assignment_id requirement
+    if requires_assignment and not args.assignment_id:
+        parser.error(f"--assignment-id is required for '{args.helper}'")
+    if args.limit is not None and args.limit < 1:
+        parser.error("--limit must be >= 1")
+    if helper_func_name == "plan_course" and not args.yaml_path:
+        parser.error("--yaml-path is required for 'plan-course'")
+
+    needs_canvas_course = helper_func_name != "plan_course" or args.publish
+    canvas_course = None
+    if needs_canvas_course:
+        if args.course_id is None:
+            parser.error("--course-id is required for this command")
+        canvas_interface = CanvasInterface(prod=args.prod)
+        canvas_course = canvas_interface.get_course(args.course_id)
+
+    # Run the requested helper
+    if helper_func_name == "delete_empty_folders":
+        delete_empty_folders(canvas_course)
+
+    elif helper_func_name == "get_closed_assignments":
+        assignments = get_closed_assignments(canvas_course)
+        log.info(f"Found {len(assignments)} closed assignments:")
+        for assignment in assignments:
+            log.info(f"  - {assignment.name} (ID: {assignment.id})")
+
+    elif helper_func_name == "get_unsubmitted_submissions":
+        assignment = canvas_course.get_assignment(args.assignment_id)
+        submissions = get_unsubmitted_submissions(canvas_course, assignment.assignment)
+        log.info(f"Found {len(submissions)} unsubmitted submissions:")
+        for submission in submissions:
+            log.info(f"  - User {submission.user_id}")
+
+    elif helper_func_name == "clear_out_missing":
+        clear_out_missing(canvas_course)
+
+    elif helper_func_name == "cleanup_missing_by_due_date":
+        stats = cleanup_missing_by_due_date(
+            canvas_course,
+            dry_run=args.dry_run,
+            include_unpublished=args.include_unpublished,
+            assignment_id=args.assignment_id,
+            limit=args.limit,
+            force_clear_stale_missing=not args.no_force_clear_stale_missing,
+            clear_placeholder_grade=args.clear_placeholder_grade,
+        )
+        log.info(f"cleanup-missing summary (dry_run={args.dry_run}):")
+        for key, value in stats.items():
+            log.info(f"  {key}: {value}")
+
+    elif helper_func_name == "deprecate_assignment":
+        deprecate_assignment(canvas_course, args.assignment_id)
+        log.info(f"Assignment {args.assignment_id} has been deprecated")
+
+    elif helper_func_name == "mark_future_assignments_as_ungraded":
+        mark_future_assignments_as_ungraded(canvas_course)
+
+    elif helper_func_name == "plan_course":
+        from lms_interface.course_plan import build_course_calendar
+
+        result = build_course_calendar(
+            plan_path=Path(args.yaml_path),
+            output_dir=Path(args.output_dir),
+            publish=args.publish,
+            publish_weekly_slides=args.publish_weekly_slides,
+            dry_run=args.dry_run,
+            canvas_course=canvas_course,
+            page_title_override=args.page_title,
+            module_name=args.module_name,
+            weekly_module_template_override=args.weekly_module_template,
+        )
+        log.info("plan-course generated outputs:")
+        for name, path in result.output_paths.items():
+            log.info(f"  {name}: {path}")
+        if result.warnings:
+            log.warning("plan-course warnings:")
+            for warning in result.warnings:
+                log.warning(f"  - {warning}")
+        if result.publish_result is not None:
+            log.info(
+                f"plan-course publish actions (dry_run={result.publish_result['dry_run']}):"
+            )
+            for action in result.publish_result["actions"]:
+                log.info(f"  - {action}")
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/lms_interface/helpers.py
+++ b/lms_interface/helpers.py
@@ -608,6 +608,11 @@ def main():
         help="Create/update attendance check-in quizzes with per-section assign-to windows (plan-course)",
     )
     parser.add_argument(
+        "--publish-assignments",
+        action="store_true",
+        help="Create/update generated course assignments (study notes/programming) from YAML rules (plan-course)",
+    )
+    parser.add_argument(
         "--weekly-module-template",
         help="Template for weekly module names, e.g. 'Week {week_number}' (plan-course)",
     )
@@ -632,11 +637,15 @@ def main():
         parser.error("--yaml-path is required for 'plan-course'")
     if (
         helper_func_name == "plan_course"
-        and (args.publish_weekly_slides or args.publish_attendance)
+        and (
+            args.publish_weekly_slides
+            or args.publish_attendance
+            or args.publish_assignments
+        )
         and not args.publish
     ):
         parser.error(
-            "--publish is required when using --publish-weekly-slides or --publish-attendance"
+            "--publish is required when using --publish-weekly-slides, --publish-attendance, or --publish-assignments"
         )
 
     needs_canvas_course = helper_func_name != "plan_course" or args.publish
@@ -697,6 +706,7 @@ def main():
             publish=args.publish,
             publish_weekly_slides=args.publish_weekly_slides,
             publish_attendance_quizzes=args.publish_attendance,
+            publish_assignments=args.publish_assignments,
             dry_run=args.dry_run,
             canvas_course=canvas_course,
             page_title_override=args.page_title,

--- a/lms_interface/tests/test_course_plan.py
+++ b/lms_interface/tests/test_course_plan.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+from lms_interface.course_plan import (
+    _build_weekly_slide_items,
+    build_schedule,
+    infer_title_from_id,
+    normalize_course_plan,
+    render_calendar_html,
+)
+
+
+def _base_plan() -> dict:
+    return {
+        "version": "1.1",
+        "term": {
+            "start_date": "2026-01-05",
+            "end_date": "2026-01-16",
+            "timezone": "America/Los_Angeles",
+            "breaks": [
+                {
+                    "name": "MW only closure",
+                    "start_date": "2026-01-12",
+                    "end_date": "2026-01-12",
+                    "applies_to": ["sec_mw"],
+                }
+            ],
+        },
+        "sections": [
+            {"id": "sec_mw", "name": "Mon/Wed", "meeting_days": ["Mon", "Wed"]},
+            {"id": "sec_tth", "name": "Tue/Thu", "meeting_days": ["Tue", "Thu"]},
+        ],
+        "sync": {
+            "mode": "lockstep_by_topic",
+            "skip_for_all_if_any_section_skips": True,
+        },
+        "topics": [
+            {"id": "topic-1", "lecture_slides": ["https://example.com/slide1.pdf"]},
+            {"id": "topic-2", "readings": ["https://example.com/read2.pdf"]},
+            {"id": "topic-3"},
+            {"id": "topic-4"},
+        ],
+        "exam_rules": {
+            "schedule_mode": "mixed",
+            "groups": [
+                {
+                    "name": "Exam 1",
+                    "through_topic": "topic-2",
+                    "fixed_date_overrides": {
+                        "sec_mw": "2026-01-14",
+                        "sec_tth": "2026-01-15",
+                    },
+                }
+            ],
+        },
+    }
+
+
+def test_infer_title_from_id_handles_ostep_and_separators():
+    assert (
+        infer_title_from_id("ostep07-process-scheduling")
+        == "OSTEP07 Process Scheduling"
+    )
+    assert infer_title_from_id("process_scheduling_os7") == "Process Scheduling Os7"
+
+
+def test_normalize_course_plan_supports_compact_resources_and_exam_coverage():
+    raw_plan = _base_plan()
+    raw_plan["topics"][0]["appears_on"] = ["Exam 1"]
+    normalized = normalize_course_plan(raw_plan)
+
+    first_topic = normalized["topics"][0]
+    assert first_topic["title"] == "Topic 1"
+    assert first_topic["lecture_slides"][0]["url"] == "https://example.com/slide1.pdf"
+    assert normalized["exam_coverage"]["Exam 1"] == ["topic-1"]
+
+
+def test_normalize_course_plan_sets_weekly_slides_publishing_defaults():
+    normalized = normalize_course_plan(_base_plan())
+
+    assert normalized["publishing"]["weekly_slides_title_prefix"] == "Slides: "
+    assert normalized["publishing"]["weekly_slides_indent"] == 1
+    assert normalized["publishing"]["weekly_slides_section_header"] == "Slides"
+    assert normalized["publishing"]["weekly_slides_prune_existing"] is True
+
+
+def test_normalize_course_plan_respects_weekly_slides_publishing_overrides():
+    raw_plan = _base_plan()
+    raw_plan["publishing"] = {
+        "weekly_slides_title_prefix": "Lecture: ",
+        "weekly_slides_indent": 2,
+        "weekly_slides_section_header": "Lecture Links",
+        "weekly_slides_prune_existing": False,
+    }
+
+    normalized = normalize_course_plan(raw_plan)
+
+    assert normalized["publishing"]["weekly_slides_title_prefix"] == "Lecture: "
+    assert normalized["publishing"]["weekly_slides_indent"] == 2
+    assert normalized["publishing"]["weekly_slides_section_header"] == "Lecture Links"
+    assert normalized["publishing"]["weekly_slides_prune_existing"] is False
+
+
+def test_normalize_course_plan_expands_relative_resources_with_base_urls():
+    raw_plan = _base_plan()
+    raw_plan["resource_defaults"] = {
+        "lecture_slides_base_url": "https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs",
+        "readings_base_url": "https://pages.cs.wisc.edu/~remzi/OSTEP/",
+    }
+    raw_plan["topics"][0]["lecture_slides"] = ["OSTEP 01.pdf"]
+    raw_plan["topics"][1]["readings"] = [{"url": "intro.pdf"}]
+
+    normalized = normalize_course_plan(raw_plan)
+
+    assert normalized["topics"][0]["lecture_slides"][0]["url"] == (
+        "https://github.com/CSUMB-SCD-instructors/CST334/tree/main/slides/pdfs/OSTEP%2001.pdf"
+    )
+    assert normalized["topics"][1]["readings"][0]["url"] == (
+        "https://pages.cs.wisc.edu/~remzi/OSTEP/intro.pdf"
+    )
+
+
+def test_build_schedule_lockstep_respects_section_specific_skip():
+    normalized = normalize_course_plan(_base_plan())
+    schedule, warnings = build_schedule(normalized)
+
+    # Week 2 loses one slot because sec_mw has a section-specific closure and lockstep skip is enabled.
+    # The remaining week-2 slot is consumed by the fixed exam date.
+    assert len(schedule["rows"]) == 3
+    assert any("did not fit" in warning for warning in warnings)
+    assert schedule["rows"][0]["topic_id"] == "topic-1"
+    assert schedule["rows"][1]["topic_id"] == "topic-2"
+    assert schedule["rows"][2]["topic_id"] is None
+    assert schedule["rows"][2]["exam_names"] == ["Exam 1"]
+
+    exam_dates = schedule["exam_dates"]["Exam 1"]
+    assert exam_dates["sec_mw"] == "2026-01-14"
+    assert exam_dates["sec_tth"] == "2026-01-15"
+
+
+def test_render_calendar_html_contains_topics_and_exam_badge():
+    normalized = normalize_course_plan(_base_plan())
+    schedule, _ = build_schedule(normalized)
+    html_output = render_calendar_html(normalized, schedule)
+
+    assert "Topic 1" in html_output
+    assert "Exam 1" in html_output
+    assert "Mon/Wed" in html_output
+    assert "Tue/Thu" in html_output
+
+
+def test_build_weekly_slide_items_groups_by_week_and_deduplicates_urls():
+    calendar_json = {
+        "rows": [
+            {
+                "week_number": 1,
+                "lecture_slides": [
+                    {"title": "Slide A", "url": "https://example.com/a.pdf"},
+                    {"title": "Slide A dup", "url": "https://example.com/a.pdf"},
+                    {"title": "Slide B", "url": "https://example.com/b.pdf"},
+                ],
+            },
+            {
+                "week_number": 2,
+                "lecture_slides": [
+                    {"title": "Slide C", "url": "https://example.com/c.pdf"},
+                ],
+            },
+        ]
+    }
+
+    weekly = _build_weekly_slide_items(
+        calendar_json,
+        module_name_template="Week {week_number}",
+    )
+
+    assert list(weekly.keys()) == ["Week 1", "Week 2"]
+    assert [item["url"] for item in weekly["Week 1"]] == [
+        "https://example.com/a.pdf",
+        "https://example.com/b.pdf",
+    ]
+    assert [item["url"] for item in weekly["Week 2"]] == ["https://example.com/c.pdf"]
+
+
+def test_build_schedule_supports_multi_hour_topics():
+    plan = {
+        "version": "1.1",
+        "term": {
+            "start_date": "2026-01-05",
+            "end_date": "2026-01-14",
+            "timezone": "America/Los_Angeles",
+        },
+        "sections": [
+            {"id": "sec_mw", "name": "Mon/Wed", "meeting_days": ["Mon", "Wed"]},
+        ],
+        "sync": {
+            "mode": "lockstep_by_topic",
+            "topics_per_meeting": 2,
+        },
+        "topics": [
+            {"id": "mlfq", "title": "MLFQ", "duration_hours": 3},
+            {"id": "sched", "title": "Scheduling", "duration_hours": 1},
+        ],
+    }
+    normalized = normalize_course_plan(plan)
+    schedule, warnings = build_schedule(normalized)
+
+    assert warnings == []
+    assert len(schedule["rows"]) >= 2
+    assert schedule["rows"][0]["topic_titles"] == ["MLFQ (2h)"]
+    assert schedule["rows"][1]["topic_titles"] == ["MLFQ", "Scheduling"]
+
+
+def test_build_schedule_derived_exam_consumes_slot():
+    plan = {
+        "version": "1.1",
+        "term": {
+            "start_date": "2026-01-05",
+            "end_date": "2026-01-15",
+            "timezone": "America/Los_Angeles",
+        },
+        "sections": [
+            {"id": "sec_mw", "name": "Mon/Wed", "meeting_days": ["Mon", "Wed"]},
+            {"id": "sec_tth", "name": "Tue/Thu", "meeting_days": ["Tue", "Thu"]},
+        ],
+        "sync": {
+            "mode": "lockstep_by_topic",
+            "skip_for_all_if_any_section_skips": True,
+        },
+        "exam_rules": {
+            "defaults": {
+                "class_meeting_index_in_week": 1,
+                "min_class_meetings_after_last_new_material": 0,
+            },
+            "groups": [
+                {
+                    "name": "Exam 1",
+                    "through_topic": "topic-2",
+                }
+            ],
+        },
+        "topics": [
+            {"id": "topic-1", "title": "Topic 1"},
+            {"id": "topic-2", "title": "Topic 2"},
+            {"id": "topic-3", "title": "Topic 3"},
+        ],
+    }
+
+    normalized = normalize_course_plan(plan)
+    schedule, warnings = build_schedule(normalized)
+
+    assert warnings == []
+    assert len(schedule["rows"]) == 4
+    assert schedule["rows"][0]["topic_id"] == "topic-1"
+    assert schedule["rows"][1]["topic_id"] == "topic-2"
+    assert schedule["rows"][2]["topic_id"] is None
+    assert schedule["rows"][2]["exam_names"] == ["Exam 1"]
+    assert schedule["rows"][3]["topic_id"] == "topic-3"
+    assert schedule["exam_dates"]["Exam 1"] == {
+        "sec_mw": "2026-01-12",
+        "sec_tth": "2026-01-13",
+    }
+
+
+def test_build_schedule_fixed_exam_outside_class_slots_adds_exam_row():
+    plan = {
+        "version": "1.1",
+        "term": {
+            "start_date": "2026-01-05",
+            "end_date": "2026-01-15",
+            "timezone": "America/Los_Angeles",
+        },
+        "sections": [
+            {"id": "sec_mw", "name": "Mon/Wed", "meeting_days": ["Mon", "Wed"]},
+        ],
+        "sync": {
+            "mode": "lockstep_by_topic",
+        },
+        "exam_rules": {
+            "groups": [
+                {
+                    "name": "Final Exam",
+                    "fixed_date_overrides": {
+                        "sec_mw": "2026-01-16",
+                    },
+                }
+            ],
+        },
+        "topics": [
+            {"id": "topic-1", "title": "Topic 1"},
+            {"id": "topic-2", "title": "Topic 2"},
+        ],
+    }
+
+    normalized = normalize_course_plan(plan)
+    schedule, warnings = build_schedule(normalized)
+
+    assert warnings == []
+    assert schedule["exam_dates"]["Final Exam"]["sec_mw"] == "2026-01-16"
+    exam_rows = [row for row in schedule["rows"] if row.get("exam_names")]
+    assert len(exam_rows) == 1
+    exam_row = exam_rows[0]
+    assert exam_row["exam_names"] == ["Final Exam"]
+    assert exam_row["slot_in_week"] == "Exam"
+    assert exam_row["topic_ids"] == []
+    assert exam_row["dates"]["sec_mw"] == "2026-01-16"
+
+
+def test_normalize_course_plan_supports_reusable_placeholders():
+    plan = {
+        "version": "1.1",
+        "term": {
+            "start_date": "2026-01-05",
+            "end_date": "2026-01-12",
+            "timezone": "America/Los_Angeles",
+        },
+        "sections": [
+            {"id": "sec_mw", "name": "Mon/Wed", "meeting_days": ["Mon", "Wed"]},
+        ],
+        "placeholders": {
+            "tbd": {
+                "title": "Buffer / TBD",
+                "new_material": False,
+                "lecture_slides": ["placeholder.pdf"],
+            }
+        },
+        "resource_defaults": {
+            "lecture_slides_base_url": "https://example.com/slides",
+        },
+        "topics": [
+            {"id": "topic-1", "title": "Topic 1"},
+            {"placeholder": "tbd", "duration_hours": 2},
+            {"placeholder": "tbd"},
+        ],
+    }
+
+    normalized = normalize_course_plan(plan)
+    topic_ids = [topic["id"] for topic in normalized["topics"]]
+    assert topic_ids == ["topic-1", "tbd-1", "tbd-2"]
+
+    second = normalized["topics"][1]
+    assert second["title"] == "Buffer / TBD"
+    assert second["new_material"] is False
+    assert second["duration_hours"] == 2
+    assert (
+        second["lecture_slides"][0]["url"]
+        == "https://example.com/slides/placeholder.pdf"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["lms_interface"]
 
 [project]
 name = "lms-interface"
-version = "0.4.3"
+version = "0.4.4"
 description = "LMS interface library for teaching tools"
 authors = [
     {name = "Sam Ogden", email = "samuel.s.ogden@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "canvasapi==3.2.0",
     "requests==2.32.2",
     "python-dotenv==1.0.1",
+    "PyYAML==6.0.3",
     "pytest>=8.4.2",
 ]
 
@@ -30,6 +31,7 @@ dev = [
     "flake8",
     "mypy",
     "ruff",
+    "jsonschema",
 ]
 
 [tool.black]

--- a/schemas/course_plan.schema.yaml
+++ b/schemas/course_plan.schema.yaml
@@ -1,0 +1,404 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "https://example.org/schemas/course_plan.schema.yaml"
+title: "Course Plan Schema"
+description: "Declarative plan for generating Canvas schedules, modules, and exam placement."
+type: object
+additionalProperties: false
+required:
+  - version
+  - term
+  - sections
+  - topics
+properties:
+  version:
+    type: string
+    enum: ["1.0", "1.1"]
+  term:
+    $ref: "#/$defs/term"
+  sections:
+    type: array
+    minItems: 1
+    items:
+      $ref: "#/$defs/section"
+  sync:
+    $ref: "#/$defs/sync"
+  topics:
+    type: array
+    minItems: 1
+    items:
+      $ref: "#/$defs/topic"
+  placeholders:
+    $ref: "#/$defs/placeholders"
+  exam_rules:
+    $ref: "#/$defs/examRules"
+  exam_coverage:
+    $ref: "#/$defs/examCoverage"
+  resource_defaults:
+    $ref: "#/$defs/resourceDefaults"
+  publishing:
+    $ref: "#/$defs/publishing"
+
+$defs:
+  date:
+    type: string
+    format: date
+
+  dayOfWeek:
+    type: string
+    enum: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+  sectionId:
+    type: string
+    pattern: "^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+
+  term:
+    type: object
+    additionalProperties: false
+    required:
+      - start_date
+      - end_date
+      - timezone
+    properties:
+      start_date:
+        $ref: "#/$defs/date"
+      end_date:
+        $ref: "#/$defs/date"
+      timezone:
+        type: string
+        minLength: 1
+      global_no_class_dates:
+        type: array
+        uniqueItems: true
+        items:
+          $ref: "#/$defs/date"
+      breaks:
+        type: array
+        items:
+          $ref: "#/$defs/breakPeriod"
+
+  breakPeriod:
+    type: object
+    additionalProperties: false
+    required:
+      - name
+      - start_date
+      - end_date
+    properties:
+      name:
+        type: string
+        minLength: 1
+      start_date:
+        $ref: "#/$defs/date"
+      end_date:
+        $ref: "#/$defs/date"
+      kind:
+        type: string
+        enum: ["break", "holiday", "reading_week", "custom"]
+      applies_to:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items:
+          $ref: "#/$defs/sectionId"
+      notes:
+        type: string
+
+  section:
+    type: object
+    additionalProperties: false
+    required:
+      - id
+      - meeting_days
+    properties:
+      id:
+        $ref: "#/$defs/sectionId"
+      name:
+        type: string
+      canvas_course_id:
+        oneOf:
+          - type: integer
+          - type: string
+            pattern: "^[0-9]+$"
+      meeting_days:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items:
+          $ref: "#/$defs/dayOfWeek"
+      meeting_time:
+        type: object
+        additionalProperties: false
+        required: [start, end]
+        properties:
+          start:
+            type: string
+            format: time
+          end:
+            type: string
+            format: time
+
+  sync:
+    type: object
+    additionalProperties: false
+    properties:
+      mode:
+        type: string
+        enum: ["lockstep_by_topic", "independent"]
+        default: "lockstep_by_topic"
+      skip_for_all_if_any_section_skips:
+        type: boolean
+        default: true
+      carry_over_policy:
+        type: string
+        enum: ["defer_topic", "compress_future"]
+        default: "defer_topic"
+      topics_per_meeting:
+        type: integer
+        minimum: 1
+        default: 1
+      hours_per_meeting:
+        type: integer
+        minimum: 1
+
+  topic:
+    type: object
+    additionalProperties: false
+    properties:
+      id:
+        type: string
+        minLength: 1
+      placeholder:
+        type: string
+        minLength: 1
+      title:
+        type: string
+        minLength: 1
+      meetings:
+        type: integer
+        minimum: 1
+        default: 1
+      duration_hours:
+        type: integer
+        minimum: 1
+      hours:
+        type: integer
+        minimum: 1
+      new_material:
+        type: boolean
+        default: true
+      readings:
+        type: array
+        items:
+          $ref: "#/$defs/resource"
+      lecture_slides:
+        type: array
+        items:
+          $ref: "#/$defs/resource"
+      resources:
+        type: array
+        items:
+          $ref: "#/$defs/resource"
+      appears_on:
+        type: array
+        items:
+          type: string
+      notes:
+        type: string
+      tags:
+        type: array
+        items:
+          type: string
+      prerequisite_topic_ids:
+        type: array
+        items:
+          type: string
+    anyOf:
+      - required: [id]
+      - required: [title]
+      - required: [placeholder]
+
+  placeholders:
+    type: object
+    additionalProperties:
+      $ref: "#/$defs/placeholderTemplate"
+
+  placeholderTemplate:
+    type: object
+    additionalProperties: false
+    properties:
+      title:
+        type: string
+      duration_hours:
+        type: integer
+        minimum: 1
+      hours:
+        type: integer
+        minimum: 1
+      new_material:
+        type: boolean
+      readings:
+        type: array
+        items:
+          $ref: "#/$defs/resource"
+      lecture_slides:
+        type: array
+        items:
+          $ref: "#/$defs/resource"
+      resources:
+        type: array
+        items:
+          $ref: "#/$defs/resource"
+      notes:
+        type: string
+      tags:
+        type: array
+        items:
+          type: string
+
+  examCoverage:
+    type: object
+    additionalProperties:
+      type: array
+      minItems: 1
+      items:
+        type: string
+
+  resourceDefaults:
+    type: object
+    additionalProperties: false
+    properties:
+      lecture_slides_base_url:
+        type: string
+        format: uri
+      readings_base_url:
+        type: string
+        format: uri
+      resources_base_url:
+        type: string
+        format: uri
+
+  resource:
+    oneOf:
+      - type: string
+        format: uri-reference
+      - type: object
+        additionalProperties: false
+        required:
+          - url
+        properties:
+          title:
+            type: string
+          type:
+            type: string
+            enum: ["reading", "lecture", "video", "worksheet", "external", "other"]
+          required:
+            type: boolean
+            default: true
+          url:
+            type: string
+            format: uri-reference
+
+  examRules:
+    type: object
+    additionalProperties: false
+    properties:
+      schedule_mode:
+        type: string
+        enum: ["derived", "fixed", "mixed"]
+        default: "derived"
+      defaults:
+        type: object
+        additionalProperties: false
+        properties:
+          class_meeting_index_in_week:
+            type: integer
+            minimum: 1
+            maximum: 7
+            default: 2
+          min_class_meetings_after_last_new_material:
+            type: integer
+            minimum: 0
+            default: 1
+          prefer_before_break:
+            type: boolean
+            default: true
+          require_before_break:
+            type: boolean
+            default: false
+      groups:
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/$defs/examGroup"
+
+  examGroup:
+    type: object
+    additionalProperties: false
+    required:
+      - name
+    properties:
+      name:
+        type: string
+        minLength: 1
+      through_topic:
+        type: string
+      included_topics:
+        type: array
+        minItems: 1
+        items:
+          type: string
+      class_meeting_index_in_week:
+        type: integer
+        minimum: 1
+        maximum: 7
+      min_class_meetings_after_last_new_material:
+        type: integer
+        minimum: 0
+      prefer_before_break:
+        type: boolean
+      require_before_break:
+        type: boolean
+      fixed_date_overrides:
+        type: object
+        patternProperties:
+          "^[a-zA-Z0-9][a-zA-Z0-9_-]*$":
+            $ref: "#/$defs/date"
+        additionalProperties: false
+      duration_minutes:
+        type: integer
+        minimum: 1
+      notes:
+        type: string
+    anyOf:
+      - required: [through_topic]
+      - required: [included_topics]
+      - required: [fixed_date_overrides]
+
+  publishing:
+    type: object
+    additionalProperties: false
+    properties:
+      module_name_template:
+        type: string
+        default: "Week {week_number}"
+      schedule_page_title:
+        type: string
+        default: "Course Schedule"
+      create_calendar_html:
+        type: boolean
+        default: true
+      weekly_slides_title_prefix:
+        type: string
+        default: "Slides: "
+      weekly_slides_indent:
+        type: integer
+        minimum: 0
+        default: 1
+      weekly_slides_section_header:
+        oneOf:
+          - type: string
+          - type: "null"
+        default: "Slides"
+      weekly_slides_prune_existing:
+        type: boolean
+        default: true

--- a/scripts/validate_course_plan.py
+++ b/scripts/validate_course_plan.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Validate a course plan YAML/JSON file against the repository schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _dependency_error(message: str) -> None:
+    print(message, file=sys.stderr)
+    print(
+        "Hint: uv run --with pyyaml --with jsonschema "
+        "python scripts/validate_course_plan.py <plan.yaml>",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+def _load_yaml_or_json(path: Path):
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    suffix = path.suffix.lower()
+    text = path.read_text(encoding="utf-8")
+
+    if suffix in {".json"}:
+        return json.loads(text)
+
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except ModuleNotFoundError:
+        _dependency_error(
+            "PyYAML is required to parse .yaml/.yml files but is not installed."
+        )
+    return yaml.safe_load(text)
+
+
+def _path_to_string(error_path) -> str:
+    parts = []
+    for part in error_path:
+        if isinstance(part, int):
+            parts.append(f"[{part}]")
+        else:
+            parts.append(f".{part}")
+    if not parts:
+        return "$"
+    return "$" + "".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a course plan file against schemas/course_plan.schema.yaml."
+    )
+    parser.add_argument("plan", help="Path to plan YAML/JSON file to validate.")
+    parser.add_argument(
+        "--schema",
+        default="schemas/course_plan.schema.yaml",
+        help="Path to JSON Schema YAML/JSON file (default: schemas/course_plan.schema.yaml).",
+    )
+    args = parser.parse_args()
+
+    plan_path = Path(args.plan)
+    schema_path = Path(args.schema)
+
+    try:
+        plan = _load_yaml_or_json(plan_path)
+        schema = _load_yaml_or_json(schema_path)
+    except json.JSONDecodeError as exc:
+        print(f"JSON parse error: {exc}", file=sys.stderr)
+        return 2
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(f"Failed to load input files: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        from jsonschema import Draft202012Validator  # type: ignore[import-not-found]
+        from jsonschema.exceptions import best_match  # type: ignore[import-not-found]
+    except ModuleNotFoundError:
+        _dependency_error("jsonschema is required but is not installed.")
+
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(plan), key=lambda e: list(e.path))
+
+    if not errors:
+        print(f"VALID: {plan_path} matches {schema_path}")
+        return 0
+
+    print(f"INVALID: {plan_path} does not match {schema_path}")
+    print(f"{len(errors)} validation error(s):")
+    for err in errors:
+        print(f"- {_path_to_string(err.path)}: {err.message}")
+        context = best_match(err.context) if err.context else None
+        if context is not None:
+            print(f"  detail: {context.message}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vendor_into_project.py
+++ b/scripts/vendor_into_project.py
@@ -26,6 +26,7 @@ FILES_TO_COPY = [
     'backends.py',
     'canvas_interface.py',
     'classes.py',
+    'course_plan.py',
     'helpers.py',
     'privacy.py',
     'interfaces.py',

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -13,6 +13,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/00/0f6e8fcdb23ea632c866620cc872729ff43ed91d284c866b515c6342b173/arrow-1.3.0.tar.gz", hash = "sha256:d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85", size = 131960, upload-time = "2023-09-30T22:11:18.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/ed/e97229a566617f2ae958a6b13e7cc0f585470eac730a73e9e82c32a3cdd2/arrow-1.3.0-py3-none-any.whl", hash = "sha256:c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80", size = 66419, upload-time = "2023-09-30T22:11:16.072Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
 ]
 
 [[package]]
@@ -171,6 +180,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "lms-interface"
 version = "0.4.4"
 source = { editable = "." }
@@ -178,6 +214,7 @@ dependencies = [
     { name = "canvasapi" },
     { name = "pytest" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "requests" },
 ]
 
@@ -185,6 +222,7 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "flake8" },
+    { name = "jsonschema" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
@@ -195,10 +233,12 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'" },
     { name = "canvasapi", specifier = "==3.2.0" },
     { name = "flake8", marker = "extra == 'dev'" },
+    { name = "jsonschema", marker = "extra == 'dev'" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = "==1.0.1" },
+    { name = "pyyaml", specifier = "==6.0.3" },
     { name = "requests", specifier = "==2.32.2" },
     { name = "ruff", marker = "extra == 'dev'" },
 ]
@@ -373,6 +413,66 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.2"
 source = { registry = "https://pypi.org/simple" }
@@ -385,6 +485,87 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/ec/535bf6f9bd280de6a4637526602a146a68fde757100ecf8c9333173392db/requests-2.32.2.tar.gz", hash = "sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289", size = 130327, upload-time = "2024-05-21T18:51:32.819Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/20/748e38b466e0819491f0ce6e90ebe4184966ee304fe483e2c414b0f4ef07/requests-2.32.2-py3-none-any.whl", hash = "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c", size = 63902, upload-time = "2024-05-21T18:51:29.562Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "lms-interface"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "canvasapi" },


### PR DESCRIPTION
## Summary
- add assignment template support in course plans (weekly study notes and programming assignments)
- generate assignment publish plans and autograder snippet output
- publish generated assignments to Canvas with assignment-group handling
- improve weekly slide and attendance publishing behavior/logging
- update course_plans/cst334_compact.yaml with assignment templates and fix malformed due-rule YAML
- include course_plan.py in vendoring script copy list

## Testing
- uv run pytest -q lms_interface/tests/test_course_plan.py lms_interface/tests/test_helpers.py
- python -m lms_interface.helpers plan-course --yaml-path course_plans/cst334_compact.yaml --output-dir build/cst334_test